### PR TITLE
Minor improvements and simplification.

### DIFF
--- a/includes/acl/clip_reader/clip_reader.h
+++ b/includes/acl/clip_reader/clip_reader.h
@@ -41,52 +41,44 @@ namespace acl
 	public:
 		ClipReader(Allocator& allocator, const char* sjson_input, size_t input_length)
 			: m_allocator(allocator)
-			, m_read_already()
 			, m_parser(sjson_input, input_length)
 			, m_error()
-			, m_skeleton()
-			, m_clip()
 			, m_version()
-			, m_num_bones()
 			, m_num_samples()
 			, m_sample_rate()
 		{
 		}
 
-		bool read(std::unique_ptr<AnimationClip, Deleter<AnimationClip>>& clip, std::shared_ptr<RigidSkeleton>& skeleton)
+		bool read(std::unique_ptr<RigidSkeleton, Deleter<RigidSkeleton>>& skeleton)
 		{
-			if (m_read_already)
-			{
-				return false;
-			}
+			reset_state();
 
-			m_read_already = true;
+			return read_version() && read_clip_header() && create_skeleton(skeleton);
+		}
 
-			if (read_version() && read_clip_header() && read_skeleton() && create_clip() && read_tracks() && nothing_follows())
-			{
-				std::swap(clip, m_clip);
-				std::swap(skeleton, m_skeleton);
-				return true;
-			}
+		bool read(std::unique_ptr<AnimationClip, Deleter<AnimationClip>>& clip, const RigidSkeleton& skeleton)
+		{
+			reset_state();
 
-			return false;
+			return read_version() && read_clip_header() && read_skeleton() && create_clip(clip, skeleton) && read_tracks(*clip, skeleton) && nothing_follows();
 		}
 
 		ClipReaderError get_error() { return m_error; }
 
 	private:
 		Allocator& m_allocator;
-		bool m_read_already;
 		SJSONParser m_parser;
 		ClipReaderError m_error;
 
-		std::shared_ptr<RigidSkeleton> m_skeleton;
-		std::unique_ptr<AnimationClip, Deleter<AnimationClip>> m_clip;
-
 		double m_version;
-		uint16_t m_num_bones;
 		uint32_t m_num_samples;
 		uint32_t m_sample_rate;
+
+		void reset_state()
+		{
+			m_parser.reset_state();
+			set_error(ClipReaderError::None);
+		}
 
 		bool read_version()
 		{
@@ -110,20 +102,14 @@ namespace acl
 			StringView clip_name;
 
 			if (!m_parser.object_begins("clip"))
-			{
 				goto error;
-			}
 			
 			if (!m_parser.read("name", clip_name))
-			{
 				goto error;
-			}
 
 			double num_samples;
 			if (!m_parser.read("num_samples", num_samples))
-			{
 				goto error;
-			}
 
 			m_num_samples = static_cast<uint32_t>(num_samples);
 			if (static_cast<double>(m_num_samples) != num_samples)
@@ -134,9 +120,7 @@ namespace acl
 
 			double sample_rate;
 			if (!m_parser.read("sample_rate", sample_rate))
-			{
 				goto error;
-			}
 
 			m_sample_rate = static_cast<uint32_t>(sample_rate);
 			if (static_cast<double>(m_sample_rate) != sample_rate)
@@ -147,15 +131,12 @@ namespace acl
 
 			double error_threshold;
 			if (!m_parser.read("error_threshold", error_threshold))
-			{
 				goto error;
-			}
+
 			// TODO: do something with error_threshold.
 
 			if (!m_parser.object_ends())
-			{
 				goto error;
-			}
 
 			return true;
 
@@ -164,27 +145,29 @@ namespace acl
 			return false;
 		}
 
-		bool read_skeleton()
+		bool create_skeleton(std::unique_ptr<RigidSkeleton, Deleter<RigidSkeleton>>& skeleton)
 		{
 			SJSONParser::State before_bones = m_parser.save_state();
 
 			uint16_t num_bones;
 			if (!process_each_bone(nullptr, num_bones))
-			{
 				return false;
-			}
 
 			m_parser.restore_state(before_bones);
 
-			std::unique_ptr<RigidBone, Deleter<RigidBone>> bones = allocate_unique_type_array<RigidBone>(m_allocator, num_bones);
+			std::unique_ptr<RigidBone, Deleter<RigidBone>> bones = make_unique_array<RigidBone>(m_allocator, num_bones);
 			if (!process_each_bone(bones.get(), num_bones))
-			{
 				return false;
-			}
 
-			m_skeleton = allocate_shared_type<RigidSkeleton>(m_allocator, m_allocator, bones.get(), num_bones);
+			skeleton = make_unique<RigidSkeleton>(m_allocator, m_allocator, bones.get(), num_bones);
 
 			return true;
+		}
+
+		bool read_skeleton()
+		{
+			uint16_t num_bones;
+			return process_each_bone(nullptr, num_bones);
 		}
 
 		bool process_each_bone(RigidBone* bones, uint16_t& num_bones)
@@ -193,9 +176,7 @@ namespace acl
 			num_bones = 0;
 
 			if (!m_parser.array_begins("bones"))
-			{
 				goto error;
-			}
 
 			for (uint16_t i = 0; !m_parser.try_array_ends(); ++i)
 			{
@@ -203,26 +184,18 @@ namespace acl
 				RigidBone& bone = counting ? dummy : bones[i];
 
 				if (!m_parser.object_begins())
-				{
 					goto error;
-				}
 
 				StringView name;
 				if (!m_parser.read("name", name))
-				{
 					goto error;
-				}
 
 				if (!counting)
-				{
 					bone.name = String(m_allocator, name);
-				}
 
 				StringView parent;
 				if (!m_parser.read("parent", parent))
-				{
 					goto error;
-				}
 				
 				if (!counting)
 				{
@@ -243,21 +216,15 @@ namespace acl
 				}
 
 				if (!m_parser.read("vertex_distance", bone.vertex_distance))
-				{
 					goto error;
-				}
 
 				double rotation[4];
 				if (m_parser.try_read("bind_rotation", rotation, 4) && !counting)
-				{
 					bone.bind_rotation = quat_unaligned_load(rotation);
-				}
 
 				double translation[3];
 				if (m_parser.try_read("bind_translation", translation, 3) && !counting)
-				{
 					bone.bind_translation = vector_unaligned_load3(translation);
-				}
 
 				double scale[3];
 				if (m_parser.try_read("bind_scale", scale, 3) && !counting)
@@ -266,9 +233,7 @@ namespace acl
 				}
 
 				if (!m_parser.object_ends())
-				{
 					goto error;
-				}
 
 				++num_bones;
 			}
@@ -285,76 +250,66 @@ namespace acl
 			for (uint16_t i = 0; i < num_bones; ++i)
 			{
 				if (bones[i].name == name)
-				{
 					return i;
-				}
 			}
 
 			return INVALID_BONE_INDEX;
 		}
 
-		bool create_clip()
+		bool create_clip(std::unique_ptr<AnimationClip, Deleter<AnimationClip>>& clip, const RigidSkeleton& skeleton)
 		{
-			m_clip = allocate_unique_type<AnimationClip>(m_allocator, m_allocator, m_skeleton, m_num_samples, m_sample_rate);
+			clip = make_unique<AnimationClip>(m_allocator, m_allocator, skeleton, m_num_samples, m_sample_rate);
 			return true;
 		}
 
-		bool read_tracks()
+		bool read_tracks(AnimationClip& clip, const RigidSkeleton& skeleton)
 		{
 			if (!m_parser.array_begins("tracks"))
-			{
 				goto error;
-			}
 
 			while (!m_parser.try_array_ends())
 			{
 				if (!m_parser.object_begins())
-				{
 					goto error;
-				}
 
 				StringView name;
 				if (!m_parser.read("name", name))
-				{
 					goto error;
-				}
 
-				uint16_t bone_index = find_bone(m_skeleton->get_bones(), m_skeleton->get_num_bones(), name);
+				uint16_t bone_index = find_bone(skeleton.get_bones(), skeleton.get_num_bones(), name);
 				if (bone_index == INVALID_BONE_INDEX)
 				{
 					set_error(ClipReaderError::NoBoneWithThatName);
 					return false;
 				}
 
-				AnimatedBone& bone = m_clip->get_bones()[bone_index];
+				AnimatedBone& bone = clip.get_bones()[bone_index];
 
 				if (m_parser.try_array_begins("rotations"))
 				{
-					if (!read_track_rotations(bone))
+					if (!read_track_rotations(bone) || !m_parser.array_ends())
 						goto error;
 				}
 				else
 				{
-					uint32_t num_samples = bone.rotation_track.get_num_samples();
-					for (uint32_t sample_index = 0; sample_index < num_samples; ++sample_index)
+					for (uint32_t sample_index = 0; sample_index < m_num_samples; ++sample_index)
 						bone.rotation_track.set_sample(sample_index, quat_identity_64());
 				}
 
 				if (m_parser.try_array_begins("translations"))
 				{
-					if (!read_track_translations(bone))
+					if (!read_track_translations(bone) || !m_parser.array_ends())
 						goto error;
 				}
 				else
 				{
-					uint32_t num_samples = bone.translation_track.get_num_samples();
-					for (uint32_t sample_index = 0; sample_index < num_samples; ++sample_index)
+					for (uint32_t sample_index = 0; sample_index < m_num_samples; ++sample_index)
 						bone.translation_track.set_sample(sample_index, vector_zero_64());
 				}
 
 				if (m_parser.try_array_begins("scales"))
 				{
-					if (!read_track_scales(bone))
+					if (!read_track_scales(bone) || !m_parser.array_ends())
 						goto error;
 				}
 				else
@@ -363,9 +318,7 @@ namespace acl
 				}
 
 				if (!m_parser.object_ends())
-				{
 					goto error;
-				}
 			}
 
 			return true;
@@ -382,14 +335,12 @@ namespace acl
 				double quaternion[4];
 
 				if (!m_parser.array_begins() || !m_parser.read(quaternion, 4) || !m_parser.array_ends())
-				{
 					return false;
-				}
 
 				bone.rotation_track.set_sample(i, quat_unaligned_load(quaternion));
 			}
 
-			return m_parser.array_ends();
+			return true;
 		}
 
 		bool read_track_translations(AnimatedBone& bone)
@@ -399,14 +350,12 @@ namespace acl
 				double translation[3];
 
 				if (!m_parser.array_begins() || !m_parser.read(translation, 3) || !m_parser.array_ends())
-				{
 					return false;
-				}
 
 				bone.translation_track.set_sample(i, vector_unaligned_load3(translation));
 			}
 
-			return m_parser.array_ends();
+			return true;
 		}
 
 		bool read_track_scales(AnimatedBone& bone)
@@ -416,14 +365,12 @@ namespace acl
 				double scale[3];
 
 				if (!m_parser.array_begins() || !m_parser.read(scale, 3) || !m_parser.array_ends())
-				{
 					return false;
-				}
 
 				// TODO: do something with scale.
 			}
 
-			return m_parser.array_ends();
+			return true;
 		}
 
 		bool nothing_follows()

--- a/includes/acl/compression/skeleton.h
+++ b/includes/acl/compression/skeleton.h
@@ -105,7 +105,7 @@ namespace acl
 
 				found_root |= is_root;
 
-				std::swap(m_bones[bone_index], bone);
+				m_bones[bone_index] = std::move(bone);
 			}
 
 			ACL_ENSURE(found_root, "No root bone found. The root bone must have a parent index = 0xFFFF");

--- a/includes/acl/core/memory.h
+++ b/includes/acl/core/memory.h
@@ -167,7 +167,7 @@ namespace acl
 	};
 
 	template<typename AllocatedType, typename... Args>
-	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> allocate_unique_type(Allocator& allocator, Args&&... args)
+	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> make_unique(Allocator& allocator, Args&&... args)
 	{
 		return std::unique_ptr<AllocatedType, Deleter<AllocatedType>>(
 			allocate_type<AllocatedType>(allocator, std::forward<Args>(args)...),
@@ -175,7 +175,7 @@ namespace acl
 	}
 
 	template<typename AllocatedType, typename... Args>
-	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> allocate_unique_type(Allocator& allocator, size_t alignment, Args&&... args)
+	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> make_unique(Allocator& allocator, size_t alignment, Args&&... args)
 	{
 		return std::unique_ptr<AllocatedType, Deleter<AllocatedType>>(
 			allocate_type<AllocatedType>(allocator, alignment, std::forward<Args>(args)...),
@@ -183,7 +183,7 @@ namespace acl
 	}
 
 	template<typename AllocatedType, typename... Args>
-	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> allocate_unique_type_array(Allocator& allocator, size_t num_elements, Args&&... args)
+	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> make_unique_array(Allocator& allocator, size_t num_elements, Args&&... args)
 	{
 		return std::unique_ptr<AllocatedType, Deleter<AllocatedType>>(
 			allocate_type_array<AllocatedType>(allocator, num_elements, std::forward<Args>(args)...),
@@ -191,41 +191,9 @@ namespace acl
 	}
 
 	template<typename AllocatedType, typename... Args>
-	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> allocate_unique_type_array(Allocator& allocator, size_t num_elements, size_t alignment, Args&&... args)
+	std::unique_ptr<AllocatedType, Deleter<AllocatedType>> make_unique_array(Allocator& allocator, size_t num_elements, size_t alignment, Args&&... args)
 	{
 		return std::unique_ptr<AllocatedType, Deleter<AllocatedType>>(
-			allocate_type_array<AllocatedType>(allocator, num_elements, alignment, std::forward<Args>(args)...),
-			Deleter<AllocatedType>(allocator));
-	}
-
-	template<typename AllocatedType, typename... Args>
-	std::shared_ptr<AllocatedType> allocate_shared_type(Allocator& allocator, Args&&... args)
-	{
-		return std::shared_ptr<AllocatedType>(
-			allocate_type<AllocatedType>(allocator, std::forward<Args>(args)...),
-			Deleter<AllocatedType>(allocator));
-	}
-
-	template<typename AllocatedType, typename... Args>
-	std::shared_ptr<AllocatedType> allocate_shared_type(Allocator& allocator, size_t alignment, Args&&... args)
-	{
-		return std::shared_ptr<AllocatedType>(
-			allocate_type<AllocatedType>(allocator, alignment, std::forward<Args>(args)...),
-			Deleter<AllocatedType>(allocator));
-	}
-
-	template<typename AllocatedType, typename... Args>
-	std::shared_ptr<AllocatedType> allocate_shared_type_array(Allocator& allocator, size_t num_elements, Args&&... args)
-	{
-		return std::shared_ptr<AllocatedType>(
-			allocate_type_array<AllocatedType>(allocator, num_elements, std::forward<Args>(args)...),
-			Deleter<AllocatedType>(allocator));
-	}
-
-	template<typename AllocatedType, typename... Args>
-	std::shared_ptr<AllocatedType> allocate_shared_type_array(Allocator& allocator, size_t num_elements, size_t alignment, Args&&... args)
-	{
-		return std::shared_ptr<AllocatedType>(
 			allocate_type_array<AllocatedType>(allocator, num_elements, alignment, std::forward<Args>(args)...),
 			Deleter<AllocatedType>(allocator));
 	}

--- a/includes/acl/core/string.h
+++ b/includes/acl/core/string.h
@@ -50,14 +50,8 @@ namespace acl
 			return *this;
 		}
 
-		String(Allocator& allocator, const char* c_string)
-			: m_chars(allocate_unique_type_array<char>(allocator, std::strlen(c_string) + 1))
-		{
-			std::memcpy(m_chars.get(), c_string, std::strlen(c_string) + 1);
-		}
-
 		String(Allocator& allocator, StringView& view)
-			: m_chars(allocate_unique_type_array<char>(allocator, view.get_length() + 1))
+			: m_chars(make_unique_array<char>(allocator, view.get_length() + 1))
 		{
 			char* own = m_chars.get();
 			std::memcpy(own, view.get_chars(), view.get_length());

--- a/includes/acl/core/string_view.h
+++ b/includes/acl/core/string_view.h
@@ -44,6 +44,12 @@ namespace acl
 		{
 		}
 
+		StringView(const char* chars)
+			: m_chars(chars)
+			, m_length(chars == nullptr ? 0 : std::strlen(chars))
+		{
+		}
+
 		StringView& operator=(const char* chars)
 		{
 			this->m_chars = chars;

--- a/includes/acl/sjson/sjson_parser.h
+++ b/includes/acl/sjson/sjson_parser.h
@@ -101,16 +101,12 @@ namespace acl
 		bool read(double* values, uint32_t num_elements)
 		{
 			if (num_elements == 0)
-			{
 				return true;
-			}
 
 			for (uint32_t i = 0; i < num_elements; ++i)
 			{
 				if (!read_double(values[i]) || i < num_elements - 1 && !read_comma())
-				{
 					return false;
-				}
 			}
 
 			return true;
@@ -139,9 +135,7 @@ namespace acl
 				restore_state(s);
 
 				for (uint32_t i = 0; i < num_elements; ++i)
-				{
 					values[i] = 0.0;
-				}
 
 				return false;
 			}
@@ -152,9 +146,7 @@ namespace acl
 		bool remainder_is_comments_and_whitespace()
 		{
 			if (!skip_comments_and_whitespace())
-			{
 				return false;
-			}
 
 			if (!eof())
 			{
@@ -170,9 +162,7 @@ namespace acl
 			while (true)
 			{
 				if (eof())
-				{
 					return true;
-				}
 
 				if (std::isspace(m_state.symbol))
 				{
@@ -185,9 +175,7 @@ namespace acl
 					advance();
 
 					if (!read_comment())
-					{
 						return false;
-					}
 				}
 
 				return true;
@@ -225,6 +213,7 @@ namespace acl
 
 		State save_state() const { return m_state; }
 		void restore_state(const State& s) { m_state = s; }
+		void reset_state() { m_state = State(m_input, m_input_length); }
 
 	private:
 		static size_t constexpr MAX_NUMBER_LENGTH = 64;
@@ -243,9 +232,7 @@ namespace acl
 		bool read_symbol(char expected, int32_t reason_if_other_found)
 		{
 			if (!skip_comments_and_whitespace_fail_if_eof())
-			{
 				return false;
-			}
 
 			if (m_state.symbol == expected)
 			{
@@ -268,9 +255,7 @@ namespace acl
 			if (m_state.symbol == '/')
 			{
 				while (!eof() && m_state.symbol != '\n')
-				{
 					advance();
-				}
 
 				return true;
 			}
@@ -314,9 +299,7 @@ namespace acl
 		bool read_key(const char* having_name)
 		{
 			if (!skip_comments_and_whitespace_fail_if_eof())
-			{
 				return false;
-			}
 
 			State start_of_key = save_state();
 			StringView actual;
@@ -324,16 +307,12 @@ namespace acl
 			if (m_state.symbol == '"')
 			{
 				if (!read_string(actual))
-				{
 					return false;
-				}
 			}
 			else
 			{
 				if (!read_unquoted_key(actual))
-				{
 					return false;
-				}
 			}
 
 			if (actual != having_name)
@@ -349,9 +328,7 @@ namespace acl
 		bool read_string(StringView& value)
 		{
 			if (!skip_comments_and_whitespace_fail_if_eof())
-			{
 				return false;
-			}
 
 			if (m_state.symbol != '"')
 			{
@@ -447,9 +424,7 @@ namespace acl
 		bool read_bool(bool& value)
 		{
 			if (!skip_comments_and_whitespace_fail_if_eof())
-			{
 				return false;
-			}
 
 			State start_of_literal = save_state();
 
@@ -487,17 +462,13 @@ namespace acl
 		bool read_double(double& value)
 		{
 			if (!skip_comments_and_whitespace_fail_if_eof())
-			{
 				return false;
-			}
 
 			size_t start_offset = m_state.offset;
 			size_t end_offset;
 
 			if (m_state.symbol == '-')
-			{
 				advance();
-			}
 
 			if (m_state.symbol == '0')
 			{
@@ -506,9 +477,7 @@ namespace acl
 			else if (std::isdigit(m_state.symbol))
 			{
 				while (std::isdigit(m_state.symbol))
-				{
 					advance();
-				}
 			}
 			else
 			{
@@ -521,9 +490,7 @@ namespace acl
 				advance();
 
 				while (std::isdigit(m_state.symbol))
-				{
 					advance();
-				}
 			}
 
 			if (m_state.symbol == 'e' || m_state.symbol == 'E')
@@ -541,9 +508,7 @@ namespace acl
 				}
 
 				while (std::isdigit(m_state.symbol))
-				{
 					advance();
-				}
 			}
 			
 			end_offset = m_state.offset - 1;
@@ -574,9 +539,7 @@ namespace acl
 		bool skip_comments_and_whitespace_fail_if_eof()
 		{
 			if (!skip_comments_and_whitespace())
-			{
 				return false;
-			}
 
 			if (eof())
 			{
@@ -590,9 +553,7 @@ namespace acl
 		bool advance()
 		{
 			if (eof())
-			{
 				return false;
-			}
 
 			m_state.offset++;
 

--- a/tools/acl_compressor/sources/main.cpp
+++ b/tools/acl_compressor/sources/main.cpp
@@ -386,7 +386,9 @@ static void try_algorithm(const Options& options, acl::Allocator& allocator, con
 	allocator.deallocate(compressed_clip, compressed_clip->get_size());
 }
 
-static bool read_clip(acl::Allocator& allocator, const char* filename, std::unique_ptr<acl::AnimationClip, acl::Deleter<acl::AnimationClip>>& clip, std::shared_ptr<acl::RigidSkeleton>& skeleton)
+static bool read_clip(acl::Allocator& allocator, const char* filename,
+					  std::unique_ptr<acl::AnimationClip, acl::Deleter<acl::AnimationClip>>& clip,
+					  std::unique_ptr<acl::RigidSkeleton, acl::Deleter<acl::RigidSkeleton>>& skeleton)
 {
 	printf("Reading ACL input clip...");
 
@@ -412,7 +414,7 @@ static bool read_clip(acl::Allocator& allocator, const char* filename, std::uniq
 
 	acl::ClipReader reader(allocator, str.c_str(), str.length());
 
-	if (!reader.read(clip, skeleton))
+	if (!reader.read(skeleton) || !reader.read(clip, *skeleton))
 	{
 		acl::ClipReaderError err = reader.get_error();
 		printf("\nError on line %d column %d: %s\n", err.line, err.column, err.get_description());
@@ -447,7 +449,7 @@ int main(int argc, char** argv)
 
 	Allocator allocator;
 	std::unique_ptr<AnimationClip, Deleter<AnimationClip>> clip;
-	std::shared_ptr<RigidSkeleton> skeleton;
+	std::unique_ptr<RigidSkeleton, Deleter<RigidSkeleton>> skeleton;
 
 	if (!read_clip(allocator, options.input_filename, clip, skeleton))
 	{


### PR DESCRIPTION
* Reused make_unique's syntax where possible

* Eliminated the need for shared_ptr as well as the functions
  supporting it.  Since the skeleton might or might not outlive the
  clip, the AnimationClip cannot keep a reference to the skeleton.

* Added StringView C string constructor to mirror the assignment op

* Dropped redundant { } bracing just one statement with no else