### PR TITLE
Align the decompression context to better use the memory cache.

### DIFF
--- a/includes/acl/algorithm/uniformly_sampled/algorithm.h
+++ b/includes/acl/algorithm/uniformly_sampled/algorithm.h
@@ -46,17 +46,28 @@ namespace acl
 			return uniformly_sampled::compress_clip(allocator, clip, skeleton, m_compression_settings);
 		}
 
-		virtual void decompress_pose(const CompressedClip& clip, float sample_time, Transform_32* out_transforms, uint16_t num_transforms) override
+		virtual void* allocate_decompression_context(Allocator& allocator, const CompressedClip& clip) override
+		{
+			uniformly_sampled::DecompressionSettings settings;
+			return uniformly_sampled::allocate_decompression_context(allocator, settings, clip);
+		}
+
+		virtual void deallocate_decompression_context(Allocator& allocator, void* context) override
+		{
+			return uniformly_sampled::deallocate_decompression_context(allocator, context);
+		}
+
+		virtual void decompress_pose(const CompressedClip& clip, void* context, float sample_time, Transform_32* out_transforms, uint16_t num_transforms) override
 		{
 			uniformly_sampled::DecompressionSettings settings;
 			AlgorithmOutputWriterImpl writer(out_transforms, num_transforms);
-			uniformly_sampled::decompress_pose(settings, clip, sample_time, writer);
+			uniformly_sampled::decompress_pose(settings, clip, context, sample_time, writer);
 		}
 
-		virtual void decompress_bone(const CompressedClip& clip, float sample_time, uint16_t sample_bone_index, Quat_32* out_rotation, Vector4_32* out_translation) override
+		virtual void decompress_bone(const CompressedClip& clip, void* context, float sample_time, uint16_t sample_bone_index, Quat_32* out_rotation, Vector4_32* out_translation) override
 		{
 			uniformly_sampled::DecompressionSettings settings;
-			uniformly_sampled::decompress_bone(settings, clip, sample_time, sample_bone_index, out_rotation, out_translation);
+			uniformly_sampled::decompress_bone(settings, clip, context, sample_time, sample_bone_index, out_rotation, out_translation);
 		}
 
 		virtual void print_stats(const CompressedClip& clip, std::FILE* file) override

--- a/includes/acl/core/ialgorithm.h
+++ b/includes/acl/core/ialgorithm.h
@@ -43,8 +43,11 @@ namespace acl
 
 		virtual CompressedClip* compress_clip(Allocator& allocator, const AnimationClip& clip, const RigidSkeleton& skeleton) = 0;
 
-		virtual void decompress_pose(const CompressedClip& clip, float sample_time, Transform_32* out_transforms, uint16_t num_transforms) = 0;
-		virtual void decompress_bone(const CompressedClip& clip, float sample_time, uint16_t sample_bone_index, Quat_32* out_rotation, Vector4_32* out_translation) = 0;
+		virtual void* allocate_decompression_context(Allocator& allocator, const CompressedClip& clip) = 0;
+		virtual void deallocate_decompression_context(Allocator& allocator, void* context) = 0;
+
+		virtual void decompress_pose(const CompressedClip& clip, void* context, float sample_time, Transform_32* out_transforms, uint16_t num_transforms) = 0;
+		virtual void decompress_bone(const CompressedClip& clip, void* context, float sample_time, uint16_t sample_bone_index, Quat_32* out_rotation, Vector4_32* out_translation) = 0;
 
 		virtual void print_stats(const CompressedClip& clip, std::FILE* file) {}
 


### PR DESCRIPTION
This change also lets the decoder perform one-time initialization and
decide itself, based on the clip, how much memory is required for the
context.  This particular decoder doesn't need a dynamically sized
context, but others (particularly the spline decoder) will.