### PR TITLE
Port to GCC on Linux

### DIFF
--- a/includes/acl/core/memory.h
+++ b/includes/acl/core/memory.h
@@ -27,7 +27,8 @@
 #include "acl/core/error.h"
 
 #include <malloc.h>
-#include <stdint.h>
+#include <cstdint>
+#include <cstring>
 #include <type_traits>
 #include <limits>
 #include <memory>
@@ -72,7 +73,11 @@ namespace acl
 
 		virtual void* allocate(size_t size, size_t alignment = DEFAULT_ALIGNMENT)
 		{
+#ifndef _WIN32
+			return aligned_alloc(size, alignment);
+#else
 			return _aligned_malloc(size, alignment);
+#endif
 		}
 
 		virtual void deallocate(void* ptr, size_t size)
@@ -80,7 +85,11 @@ namespace acl
 			if (ptr == nullptr)
 				return;
 
+#ifndef _WIN32
+			free(ptr);
+#else
 			_aligned_free(ptr);
+#endif
 		}
 	};
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,10 @@ if(MSVC)
 
 	# Add linker flags
 	set(CMAKE_EXE_LINKER_FLAGS /DEBUG)
+else()
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86" OR CMAKE_SYSTEM_PROCESSOR MATCHES "amd64")
+		target_compile_options(acl_unit_tests PRIVATE "-msse4.1")
+	endif()
 endif()
 
 install(TARGETS acl_unit_tests RUNTIME DESTINATION bin)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.9)
 project(acl_unit_tests)
 
+set(CMAKE_CXX_STANDARD 14)
+
 include_directories("${PROJECT_SOURCE_DIR}/../includes")
 include_directories("${PROJECT_SOURCE_DIR}/external/catch-1.9.6")
 

--- a/tests/sources/main.cpp
+++ b/tests/sources/main.cpp
@@ -1,6 +1,19 @@
 #define CATCH_CONFIG_RUNNER
 #include <catch.hpp>
+
+#ifndef _WIN32
+static int _kbhit()
+{
+	return 0;
+}
+
+static bool IsDebuggerPresent()
+{
+	return false;
+}
+#else // _WIN32
 #include <conio.h>
+#endif // _WIN32
 
 int main(int argc, char* argv[])
 {

--- a/tools/acl_compressor/CMakeLists.txt
+++ b/tools/acl_compressor/CMakeLists.txt
@@ -29,6 +29,10 @@ if(MSVC)
 
 	# Add linker flags
 	set(CMAKE_EXE_LINKER_FLAGS /DEBUG)
+else()
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86" OR CMAKE_SYSTEM_PROCESSOR MATCHES "amd64")
+		target_compile_options(acl_compressor PRIVATE "-msse4.1")
+	endif()
 endif()
 
 install(TARGETS acl_compressor RUNTIME DESTINATION bin)

--- a/tools/acl_compressor/CMakeLists.txt
+++ b/tools/acl_compressor/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.9)
 project(acl_compressor)
 
+set(CMAKE_CXX_STANDARD 14)
+
 include_directories("${PROJECT_SOURCE_DIR}/../../includes")
 
 # Grab all of our source files
@@ -9,6 +11,7 @@ file(GLOB_RECURSE ACL_COMPRESSOR_SOURCE_FILES
 	${PROJECT_SOURCE_DIR}/*.py)
 
 add_executable(acl_compressor ${ACL_COMPRESSOR_SOURCE_FILES})
+
 
 if(MSVC)
 	# Replace some default compiler switches and add new ones

--- a/tools/acl_compressor/sources/main.cpp
+++ b/tools/acl_compressor/sources/main.cpp
@@ -32,7 +32,6 @@
 
 #include "acl/algorithm/uniformly_sampled/algorithm.h"
 
-#include <conio.h>
 #include <cstring>
 #include <cstdio>
 #include <fstream>
@@ -41,6 +40,8 @@
 #include <string>
 #include <memory>
 
+#ifdef _WIN32
+#include <conio.h>
 #if !defined(_WINDOWS_)
 // The below excludes some other unused services from the windows headers -- see windows.h for details.
 #define NOGDICAPMASKS            // CC_*, LC_*, PC_*, CP_*, TC_*, RC_
@@ -90,6 +91,7 @@
 
 #include <windows.h>
 #endif    // _WINDOWS_
+#endif    // _WIN32
 
 using namespace acl;
 
@@ -260,6 +262,18 @@ static void try_algorithm(const Options& options, Allocator& allocator, const An
 		try_algorithm_impl(nullptr);
 	
 }
+
+#ifndef _WIN32
+static int _kbhit()
+{
+	return 0;
+}
+
+static bool IsDebuggerPresent()
+{
+	return false;
+}
+#endif
 
 static bool read_clip(Allocator& allocator, const char* filename,
 					  std::unique_ptr<AnimationClip, Deleter<AnimationClip>>& clip,


### PR DESCRIPTION
```
===============================================================================
All tests passed (170 assertions in 6 test cases)
```

Consider this a proof of concept, you shouldn't really be using `conio.h` in 2017…

`#include <windows.h>` is also a bit iffy in this case, but I'll let you solve that yourself.