### PR TITLE
Add Xcode9 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
           packages:
             - clang-5.0
             - libstdc++-5-dev
+    - os: osx
+      osx_image: xcode9
 
 # prevent Travis from overwriting our CXX variables
 before_install:


### PR DESCRIPTION
This is just so you can see how to add xcode to travis and see where the build is failing