### PR TITLE
Make sure not to pass invalid arguments to _mm_shuffle_pd

### DIFF
--- a/includes/acl/math/quat_64.h
+++ b/includes/acl/math/quat_64.h
@@ -86,7 +86,7 @@ namespace acl
 	inline double quat_get_y(const Quat_64& input)
 	{
 #if defined(ACL_SSE2_INTRINSICS)
-		return _mm_cvtsd_f64(_mm_shuffle_pd(input.xy, input.xy, _MM_SHUFFLE(1, 1, 1, 1)));
+		return _mm_cvtsd_f64(_mm_shuffle_pd(input.xy, input.xy, 1));
 #else
 		return input.y;
 #endif
@@ -104,7 +104,7 @@ namespace acl
 	inline double quat_get_w(const Quat_64& input)
 	{
 #if defined(ACL_SSE2_INTRINSICS)
-		return _mm_cvtsd_f64(_mm_shuffle_pd(input.zw, input.zw, _MM_SHUFFLE(1, 1, 1, 1)));
+		return _mm_cvtsd_f64(_mm_shuffle_pd(input.zw, input.zw, 1));
 #else
 		return input.w;
 #endif

--- a/includes/acl/math/vector4_64.h
+++ b/includes/acl/math/vector4_64.h
@@ -125,7 +125,7 @@ namespace acl
 	inline double vector_get_y(const Vector4_64& input)
 	{
 #if defined(ACL_SSE2_INTRINSICS)
-		return _mm_cvtsd_f64(_mm_shuffle_pd(input.xy, input.xy, _MM_SHUFFLE(1, 1, 1, 1)));
+		return _mm_cvtsd_f64(_mm_shuffle_pd(input.xy, input.xy, 1));
 #else
 		return input.y;
 #endif
@@ -143,7 +143,7 @@ namespace acl
 	inline double vector_get_w(const Vector4_64& input)
 	{
 #if defined(ACL_SSE2_INTRINSICS)
-		return _mm_cvtsd_f64(_mm_shuffle_pd(input.zw, input.zw, _MM_SHUFFLE(1, 1, 1, 1)));
+		return _mm_cvtsd_f64(_mm_shuffle_pd(input.zw, input.zw, 1));
 #else
 		return input.w;
 #endif


### PR DESCRIPTION
_mm_shuffle_pd only takes 4 possible values as the immediate argument,
documented in relevant headers:
https://github.com/llvm-mirror/clang/blob/0b9709a03e14e41a6ab4b551e0f339bd24d2fc03/lib/Headers/emmintrin.h#L4755-L4758
Intel's documentation:
https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_shuffle_pd&expand=4795,4784,4795,4784
and other places:
https://www.felixcloutier.com/x86/SHUFPD.html

This commit removes the mask creating invalid arguments and replaces it
with expected literals.