### PR TITLE
Fix compilation warning on OSX.

### DIFF
--- a/includes/acl/io/clip_reader.h
+++ b/includes/acl/io/clip_reader.h
@@ -368,7 +368,7 @@ namespace acl
 				uint64_t u64;
 				double dbl;
 
-				constexpr explicit UInt64ToDouble(uint64_t value) : u64(value) {}
+				constexpr explicit UInt64ToDouble(uint64_t u64_value) : u64(u64_value) {}
 			};
 
 			ACL_ASSERT(value.size() <= 16, "Invalid binary exact double value");

--- a/includes/acl/io/clip_writer.h
+++ b/includes/acl/io/clip_writer.h
@@ -47,7 +47,7 @@ namespace acl
 				uint64_t u64;
 				double dbl;
 
-				constexpr explicit DoubleToUInt64(double value) : dbl(value) {}
+				constexpr explicit DoubleToUInt64(double dbl_value) : dbl(dbl_value) {}
 			};
 
 			snprintf(buffer, buffer_size, "%" PRIX64, DoubleToUInt64(value).u64);


### PR DESCRIPTION
Fix two warning when compiling for UE4 Editor on Mac. I simply renamed the variable that was unhappy with the shadowing.

clip_reader.h:371:48: error: declaration shadows a local variable [-Werror,-Wshadow]
clip_writer.h:50:46: error: declaration shadows a local variable [-Werror,-Wshadow]