### PR TITLE
Promote types to preempt integer overflow

### DIFF
--- a/includes/acl/compression/animation_track.h
+++ b/includes/acl/compression/animation_track.h
@@ -87,7 +87,7 @@ namespace acl
 		//    - type: The track type
 		AnimationTrack(IAllocator& allocator, uint32_t num_samples, uint32_t sample_rate, AnimationTrackType8 type)
 			: m_allocator(&allocator)
-			, m_sample_data(allocate_type_array_aligned<double>(allocator, num_samples * get_animation_track_sample_size(type), alignof(Vector4_64)))
+			, m_sample_data(allocate_type_array_aligned<double>(allocator, size_t(num_samples) * get_animation_track_sample_size(type), alignof(Vector4_64)))
 			, m_num_samples(num_samples)
 			, m_sample_rate(sample_rate)
 			, m_type(type)
@@ -96,7 +96,7 @@ namespace acl
 		~AnimationTrack()
 		{
 			if (is_initialized())
-				deallocate_type_array(*m_allocator, m_sample_data, m_num_samples * get_animation_track_sample_size(m_type));
+				deallocate_type_array(*m_allocator, m_sample_data, size_t(m_num_samples) * get_animation_track_sample_size(m_type));
 		}
 
 		AnimationTrack& operator=(AnimationTrack&& track)

--- a/includes/acl/compression/skeleton.h
+++ b/includes/acl/compression/skeleton.h
@@ -234,7 +234,7 @@ namespace acl
 
 			m_num_leaf_bones = safe_static_cast<uint16_t>(bitset_count_set_bits(is_leaf_bitset, bone_bitset_desc));
 
-			m_leaf_bone_chains = allocate_type_array<uint32_t>(allocator, m_num_leaf_bones * bone_bitset_desc.get_size());
+			m_leaf_bone_chains = allocate_type_array<uint32_t>(allocator, size_t(m_num_leaf_bones) * bone_bitset_desc.get_size());
 
 			uint16_t leaf_index = 0;
 			for (uint16_t bone_index = 0; bone_index < num_bones; ++bone_index)
@@ -272,7 +272,7 @@ namespace acl
 			deallocate_type_array(m_allocator, m_bones, m_num_bones);
 
 			BitSetDescription bone_bitset_desc = BitSetDescription::make_from_num_bits(m_num_bones);
-			deallocate_type_array(m_allocator, m_leaf_bone_chains, m_num_leaf_bones * bone_bitset_desc.get_size());
+			deallocate_type_array(m_allocator, m_leaf_bone_chains, size_t(m_num_leaf_bones) * bone_bitset_desc.get_size());
 		}
 
 		RigidSkeleton(const RigidSkeleton&) = delete;

--- a/includes/acl/compression/stream/segment_streams.h
+++ b/includes/acl/compression/stream/segment_streams.h
@@ -116,7 +116,7 @@ namespace acl
 				{
 					uint32_t sample_size = clip_bone_stream.rotations.get_sample_size();
 					RotationTrackStream rotations(allocator, num_samples_in_segment, sample_size, clip_bone_stream.rotations.get_sample_rate(), clip_bone_stream.rotations.get_rotation_format(), clip_bone_stream.rotations.get_bit_rate());
-					memcpy(rotations.get_raw_sample_ptr(0), clip_bone_stream.rotations.get_raw_sample_ptr(clip_sample_index), num_samples_in_segment * sample_size);
+					memcpy(rotations.get_raw_sample_ptr(0), clip_bone_stream.rotations.get_raw_sample_ptr(clip_sample_index), size_t(num_samples_in_segment) * sample_size);
 
 					segment_bone_stream.rotations = std::move(rotations);
 				}
@@ -129,7 +129,7 @@ namespace acl
 				{
 					uint32_t sample_size = clip_bone_stream.translations.get_sample_size();
 					TranslationTrackStream translations(allocator, num_samples_in_segment, sample_size, clip_bone_stream.translations.get_sample_rate(), clip_bone_stream.translations.get_vector_format(), clip_bone_stream.translations.get_bit_rate());
-					memcpy(translations.get_raw_sample_ptr(0), clip_bone_stream.translations.get_raw_sample_ptr(clip_sample_index), num_samples_in_segment * sample_size);
+					memcpy(translations.get_raw_sample_ptr(0), clip_bone_stream.translations.get_raw_sample_ptr(clip_sample_index), size_t(num_samples_in_segment) * sample_size);
 
 					segment_bone_stream.translations = std::move(translations);
 				}
@@ -142,7 +142,7 @@ namespace acl
 				{
 					uint32_t sample_size = clip_bone_stream.scales.get_sample_size();
 					ScaleTrackStream scales(allocator, num_samples_in_segment, sample_size, clip_bone_stream.scales.get_sample_rate(), clip_bone_stream.scales.get_vector_format(), clip_bone_stream.scales.get_bit_rate());
-					memcpy(scales.get_raw_sample_ptr(0), clip_bone_stream.scales.get_raw_sample_ptr(clip_sample_index), num_samples_in_segment * sample_size);
+					memcpy(scales.get_raw_sample_ptr(0), clip_bone_stream.scales.get_raw_sample_ptr(clip_sample_index), size_t(num_samples_in_segment) * sample_size);
 
 					segment_bone_stream.scales = std::move(scales);
 				}

--- a/includes/acl/compression/stream/track_stream.h
+++ b/includes/acl/compression/stream/track_stream.h
@@ -148,7 +148,7 @@ namespace acl
 				copy.m_format = m_format;
 				copy.m_bit_rate = m_bit_rate;
 
-				std::memcpy(copy.m_samples, m_samples, m_sample_size * m_num_samples);
+				std::memcpy(copy.m_samples, m_samples, (size_t)m_sample_size * m_num_samples);
 			}
 		}
 


### PR DESCRIPTION
When calling functions expecting size_t (e.g. memcpy) with a count being
the result of a multiplication of integer values, the multiplication is
done within the types of arguments, which may not yield the expected
value. To preemptively prevent such issue, promote the type of first
multiplication argument to the destination type making the whole
expression of such type.