### PR TITLE
perf(decompression): optimize the decompression seek function

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -46,6 +46,10 @@ In order to run these manually:
 
 Note that *iOS* builds have never been tested on an emulator.
 
+## Commit message format
+
+This library uses the [angular.js message format](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits) and it is enforced with commit linting through every pull request.
+
 ## Generating the stats and graphs
 
 See [here](graph_generation.md) to find out how the various statistics and graphs we track are generated.

--- a/includes/acl/compression/animation_clip.h
+++ b/includes/acl/compression/animation_clip.h
@@ -276,6 +276,9 @@ namespace acl
 			if (m_num_samples == 0)
 				return ErrorResult("Clip has no samples");
 
+			if (m_num_samples == 0xFFFFFFFFu)
+				return ErrorResult("Clip has too many samples");
+
 			if (m_sample_rate <= 0.0f)
 				return ErrorResult("Clip has an invalid sample rate");
 

--- a/includes/acl/compression/stream/clip_context.h
+++ b/includes/acl/compression/stream/clip_context.h
@@ -61,7 +61,8 @@ namespace acl
 		AdditiveClipFormat8 additive_format;
 
 		// Stat tracking
-		uint32_t total_header_size;
+		uint32_t decomp_touched_bytes;
+		uint32_t decomp_touched_cache_lines;
 
 		//////////////////////////////////////////////////////////////////////////
 
@@ -143,7 +144,8 @@ namespace acl
 		}
 
 		out_clip_context.has_scale = has_scale;
-		out_clip_context.total_header_size = 0;
+		out_clip_context.decomp_touched_bytes = 0;
+		out_clip_context.decomp_touched_cache_lines = 0;
 
 		segment.bone_streams = bone_streams;
 		segment.clip = &out_clip_context;

--- a/includes/acl/compression/stream/quantize_streams.h
+++ b/includes/acl/compression/stream/quantize_streams.h
@@ -1197,7 +1197,7 @@ namespace acl
 			{
 				float error = calculate_max_error_at_bit_rate(context, i, false, true);
 				const BoneBitRate& bone_bit_rate = context.bit_rate_per_bone[i];
-				printf("%u: %u | %u | %u => %f %s\n", i, bone_bit_rate.rotation, bone_bit_rate.translation, bone_bit_rate.scale, error, error >= context.error_threshold ? "!" : "");
+				printf("%u: %u | %u | %u => %f %s\n", i, bone_bit_rate.rotation, bone_bit_rate.translation, bone_bit_rate.scale, error, error >= settings.error_threshold ? "!" : "");
 			}
 #endif
 

--- a/includes/acl/compression/stream/segment_streams.h
+++ b/includes/acl/compression/stream/segment_streams.h
@@ -47,18 +47,31 @@ namespace acl
 		if (clip_context.num_samples <= settings.max_num_samples)
 			return;
 
-		uint32_t num_segments = (clip_context.num_samples + settings.ideal_num_samples - 1) / settings.ideal_num_samples;
-		uint32_t max_num_samples = num_segments * settings.ideal_num_samples;
+		//////////////////////////////////////////////////////////////////////////
+		// This algorithm is simple in nature. Its primary aim is to avoid having
+		// the last segment being partial if multiple segments are present.
+		// The extra samples from the last segment will be redistributed evenly
+		// starting with the first segment.
+		// As such, in order to quickly find which segment contains a particular sample
+		// you can simply divide the number of samples by the number of segments to get
+		// the floored value of number of samples per segment. This guarantees an accurate estimate.
+		// You can then query the segment start index by dividing the desired sample index
+		// with the floored value. If the sample isn't in the current segment, it will live in one of its neighbors.
+		// TODO: Can we provide a tighter guarantee?
+		//////////////////////////////////////////////////////////////////////////
 
-		uint32_t original_num_segments = num_segments;
+		uint32_t num_segments = (clip_context.num_samples + settings.ideal_num_samples - 1) / settings.ideal_num_samples;
+		const uint32_t max_num_samples = num_segments * settings.ideal_num_samples;
+
+		const uint32_t original_num_segments = num_segments;
 		uint32_t* num_samples_per_segment = allocate_type_array<uint32_t>(allocator, num_segments);
 		std::fill(num_samples_per_segment, num_samples_per_segment + num_segments, settings.ideal_num_samples);
 
-		uint32_t num_leftover_samples = settings.ideal_num_samples - (max_num_samples - clip_context.num_samples);
+		const uint32_t num_leftover_samples = settings.ideal_num_samples - (max_num_samples - clip_context.num_samples);
 		if (num_leftover_samples != 0)
 			num_samples_per_segment[num_segments - 1] = num_leftover_samples;
 
-		uint32_t slack = settings.max_num_samples - settings.ideal_num_samples;
+		const uint32_t slack = settings.max_num_samples - settings.ideal_num_samples;
 		if ((num_segments - 1) * slack >= num_leftover_samples)
 		{
 			// Enough segments to distribute the leftover samples of the last segment
@@ -83,7 +96,7 @@ namespace acl
 		uint32_t clip_sample_index = 0;
 		for (uint32_t segment_index = 0; segment_index < num_segments; ++segment_index)
 		{
-			uint32_t num_samples_in_segment = num_samples_per_segment[segment_index];
+			const uint32_t num_samples_in_segment = num_samples_per_segment[segment_index];
 
 			SegmentContext& segment = clip_context.segments[segment_index];
 			segment.clip = &clip_context;
@@ -118,7 +131,7 @@ namespace acl
 				}
 				else
 				{
-					uint32_t sample_size = clip_bone_stream.rotations.get_sample_size();
+					const uint32_t sample_size = clip_bone_stream.rotations.get_sample_size();
 					RotationTrackStream rotations(allocator, num_samples_in_segment, sample_size, clip_bone_stream.rotations.get_sample_rate(), clip_bone_stream.rotations.get_rotation_format(), clip_bone_stream.rotations.get_bit_rate());
 					memcpy(rotations.get_raw_sample_ptr(0), clip_bone_stream.rotations.get_raw_sample_ptr(clip_sample_index), size_t(num_samples_in_segment) * sample_size);
 
@@ -131,7 +144,7 @@ namespace acl
 				}
 				else
 				{
-					uint32_t sample_size = clip_bone_stream.translations.get_sample_size();
+					const uint32_t sample_size = clip_bone_stream.translations.get_sample_size();
 					TranslationTrackStream translations(allocator, num_samples_in_segment, sample_size, clip_bone_stream.translations.get_sample_rate(), clip_bone_stream.translations.get_vector_format(), clip_bone_stream.translations.get_bit_rate());
 					memcpy(translations.get_raw_sample_ptr(0), clip_bone_stream.translations.get_raw_sample_ptr(clip_sample_index), size_t(num_samples_in_segment) * sample_size);
 
@@ -144,7 +157,7 @@ namespace acl
 				}
 				else
 				{
-					uint32_t sample_size = clip_bone_stream.scales.get_sample_size();
+					const uint32_t sample_size = clip_bone_stream.scales.get_sample_size();
 					ScaleTrackStream scales(allocator, num_samples_in_segment, sample_size, clip_bone_stream.scales.get_sample_rate(), clip_bone_stream.scales.get_vector_format(), clip_bone_stream.scales.get_bit_rate());
 					memcpy(scales.get_raw_sample_ptr(0), clip_bone_stream.scales.get_raw_sample_ptr(clip_sample_index), size_t(num_samples_in_segment) * sample_size);
 

--- a/includes/acl/compression/stream/write_stats.h
+++ b/includes/acl/compression/stream/write_stats.h
@@ -89,11 +89,11 @@ namespace acl
 		// We assume that we always interpolate between 2 poses
 		const uint32_t animated_pose_byte_size = align_to(segment.animated_pose_bit_size * 2, 8) / 8;
 		constexpr uint32_t k_cache_line_byte_size = 64;
-		const uint32_t num_clip_header_cache_lines = align_to(segment.clip->total_header_size, k_cache_line_byte_size) / k_cache_line_byte_size;
+
 		const uint32_t num_segment_header_cache_lines = align_to(segment.total_header_size, k_cache_line_byte_size) / k_cache_line_byte_size;
 		const uint32_t num_animated_pose_cache_lines = align_to(animated_pose_byte_size, k_cache_line_byte_size) / k_cache_line_byte_size;
-		writer["decomp_touched_bytes"] = segment.clip->total_header_size + segment.total_header_size + animated_pose_byte_size;
-		writer["decomp_touched_cache_lines"] = num_clip_header_cache_lines + num_segment_header_cache_lines + num_animated_pose_cache_lines;
+		writer["decomp_touched_bytes"] = segment.clip->decomp_touched_bytes + segment.total_header_size + animated_pose_byte_size;
+		writer["decomp_touched_cache_lines"] = segment.clip->decomp_touched_cache_lines + num_segment_header_cache_lines + num_animated_pose_cache_lines;
 	}
 
 	inline void write_exhaustive_segment_stats(IAllocator& allocator, const SegmentContext& segment, const ClipContext& raw_clip_context, const ClipContext& additive_base_clip_context, const RigidSkeleton& skeleton, const CompressionSettings& settings, sjson::ObjectWriter& writer)

--- a/includes/acl/core/algorithm_versions.h
+++ b/includes/acl/core/algorithm_versions.h
@@ -43,7 +43,7 @@ namespace acl
 	{
 		switch (type)
 		{
-			case AlgorithmType8::UniformlySampled:		return 4;
+			case AlgorithmType8::UniformlySampled:		return 5;
 			//case AlgorithmType8::LinearKeyReduction:	return 0;
 			//case AlgorithmType8::SplineKeyReduction:	return 0;
 			default:									return 0xFFFF;

--- a/includes/acl/core/compressed_clip.h
+++ b/includes/acl/core/compressed_clip.h
@@ -155,9 +155,6 @@ namespace acl
 	////////////////////////////////////////////////////////////////////////////////
 	struct SegmentHeader
 	{
-		// Number of samples the segment was constructed from per track.
-		uint32_t				num_samples;
-
 		// Number of bits used by a fully animated pose (excludes default/constant tracks).
 		uint32_t				animated_pose_bit_size;						// TODO: Calculate from bitsets and formats?
 
@@ -198,6 +195,8 @@ namespace acl
 		// Whether the default scale is 0,0,0 or 1,1,1 (bool/bit).
 		uint8_t					default_scale;
 
+		uint8_t padding[1];
+
 		// The total number of samples per track our clip contained.
 		uint32_t				num_samples;
 
@@ -205,6 +204,7 @@ namespace acl
 		float					sample_rate;								// TODO: Store duration as float instead
 
 		// Offset to the segment headers data.
+		PtrOffset16<uint32_t>		segment_start_indices_offset;
 		PtrOffset16<SegmentHeader>	segment_headers_offset;
 
 		// Offsets to the default/constant tracks bitsets.
@@ -219,6 +219,9 @@ namespace acl
 
 		//////////////////////////////////////////////////////////////////////////
 		// Utility functions that return pointers from their respective offsets.
+
+		uint32_t*		get_segment_start_indices()			{ return segment_start_indices_offset.safe_add_to(this); }
+		const uint32_t*	get_segment_start_indices() const	{ return segment_start_indices_offset.safe_add_to(this); }
 
 		SegmentHeader*			get_segment_headers()		{ return segment_headers_offset.add_to(this); }
 		const SegmentHeader*	get_segment_headers() const	{ return segment_headers_offset.add_to(this); }

--- a/includes/acl/core/interpolation_utils.h
+++ b/includes/acl/core/interpolation_utils.h
@@ -64,6 +64,7 @@ namespace acl
 	//////////////////////////////////////////////////////////////////////////
 	// Calculates the sample indices and the interpolation required to linearly
 	// interpolate when the samples are uniform.
+	// The returned sample indices are clamped and do not loop.
 	// If the sample rate is available, prefer using find_linear_interpolation_samples_with_sample_rate
 	// instead. It is faster and more accurate.
 	inline void find_linear_interpolation_samples_with_duration(uint32_t num_samples, float duration, float sample_time, SampleRoundingPolicy rounding_policy,
@@ -116,6 +117,7 @@ namespace acl
 	//////////////////////////////////////////////////////////////////////////
 	// Calculates the sample indices and the interpolation required to linearly
 	// interpolate when the samples are uniform.
+	// The returned sample indices are clamped and do not loop.
 	inline void find_linear_interpolation_samples_with_sample_rate(uint32_t num_samples, float sample_rate, float sample_time, SampleRoundingPolicy rounding_policy,
 		uint32_t& out_sample_index0, uint32_t& out_sample_index1, float& out_interpolation_alpha)
 	{

--- a/make.py
+++ b/make.py
@@ -11,7 +11,7 @@ import zipfile
 
 # The current test/decompression data version in use
 current_test_data = 'test_data_v1'
-current_decomp_data = 'decomp_data_v3'
+current_decomp_data = 'decomp_data_v4'
 
 def parse_argv():
 	parser = argparse.ArgumentParser(add_help=False)

--- a/tools/acl_decompressor/acl_decompressor.py
+++ b/tools/acl_decompressor/acl_decompressor.py
@@ -19,7 +19,7 @@ import sjson
 
 def parse_argv():
 	options = {}
-	options['acl'] = os.path.join(os.getcwd(), '../../test_data/decomp_data_v3')
+	options['acl'] = os.path.join(os.getcwd(), '../../test_data/decomp_data_v4')
 	options['stats'] = ""
 	options['csv'] = False
 	options['refresh'] = False


### PR DESCRIPTION
perf(decompression): Optimize the decompression seek function

The old function performed a linear search to find the segments
we need to sample a time T. This can be slow for long clips.
Instead we now make an approximate guess where the first
segment we need lives since the segment sizes are near uniform.
This allows us to only check neighboring segments in O(1).

Includes minor changes and cleanup as well.

Fixes #185