### PR TITLE
fix(setup): various python and android fixes

### DIFF
--- a/cmake/Toolchain-Android.cmake
+++ b/cmake/Toolchain-Android.cmake
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.2)
+include(ProcessorCount)
 
 set(CMAKE_SYSTEM_NAME Android)
 
@@ -6,4 +7,4 @@ set(CMAKE_SYSTEM_NAME Android)
 set(CMAKE_GENERATOR_TOOLSET DefaultClang)
 
 # Make sure we use all our processors when building
-set(CMAKE_ANDROID_PROCESS_MAX $ENV{NUMBER_OF_PROCESSORS})
+ProcessorCount(CMAKE_ANDROID_PROCESS_MAX)

--- a/make.py
+++ b/make.py
@@ -480,7 +480,7 @@ def do_regression_tests(ctest_exe, test_data_dir, args):
 	# Iterate over every clip and configuration and perform the regression testing
 	for config_filename, _ in test_configs:
 		print('Performing regression tests for configuration: {}'.format(os.path.basename(config_filename)))
-		regression_start_time = time.clock()
+		regression_start_time = time.perf_counter()
 
 		cmd_queue = queue.Queue()
 		completed_queue = queue.Queue()
@@ -542,7 +542,7 @@ def do_regression_tests(ctest_exe, test_data_dir, args):
 
 		regression_testing_failed = not failed_queue.empty()
 
-		regression_end_time = time.clock()
+		regression_end_time = time.perf_counter()
 		print('Done in {}'.format(format_elapsed_time(regression_end_time - regression_start_time)))
 
 		if regression_testing_failed:

--- a/make.py
+++ b/make.py
@@ -343,24 +343,24 @@ def do_prepare_regression_test_data(test_data_dir, args):
 
 	print('Found {} regression configurations'.format(len(test_configs)))
 
-	if needs_decompression:
-		# Sort the configs by name for consistency
-		test_configs.sort(key=lambda entry: entry[1])
+	# Sort the configs by name for consistency
+	test_configs.sort(key=lambda entry: entry[1])
 
-		# Sort clips by size to test larger clips first, it parallelizes better
-		regression_clips.sort(key=lambda entry: entry[1], reverse=True)
+	# Sort clips by size to test larger clips first, it parallelizes better
+	regression_clips.sort(key=lambda entry: entry[1], reverse=True)
 
-		with open(os.path.join(current_test_data_dir, 'metadata.sjson'), 'w') as metadata_file:
-			print('configs = [', file = metadata_file)
-			for config_filename, _ in test_configs:
-				print('\t"{}"'.format(os.path.relpath(config_filename, test_config_dir)), file = metadata_file)
-			print(']', file = metadata_file)
-			print('', file = metadata_file)
-			print('clips = [', file = metadata_file)
-			for clip_filename, _ in regression_clips:
-				print('\t"{}"'.format(os.path.relpath(clip_filename, current_test_data_dir)), file = metadata_file)
-			print(']', file = metadata_file)
-			print('', file = metadata_file)
+	# Write our metadata file
+	with open(os.path.join(current_test_data_dir, 'metadata.sjson'), 'w') as metadata_file:
+		print('configs = [', file = metadata_file)
+		for config_filename, _ in test_configs:
+			print('\t"{}"'.format(os.path.relpath(config_filename, test_config_dir)), file = metadata_file)
+		print(']', file = metadata_file)
+		print('', file = metadata_file)
+		print('clips = [', file = metadata_file)
+		for clip_filename, _ in regression_clips:
+			print('\t"{}"'.format(os.path.relpath(clip_filename, current_test_data_dir)), file = metadata_file)
+		print(']', file = metadata_file)
+		print('', file = metadata_file)
 
 	return current_test_data_dir
 
@@ -419,18 +419,18 @@ def do_prepare_decompression_test_data(test_data_dir, args):
 
 	print('Found {} decompression configurations'.format(len(configs)))
 
-	if needs_decompression:
-		with open(os.path.join(current_data_dir, 'metadata.sjson'), 'w') as metadata_file:
-			print('configs = [', file = metadata_file)
-			for config_filename in configs:
-				print('\t"{}"'.format(os.path.relpath(config_filename, config_dir)), file = metadata_file)
-			print(']', file = metadata_file)
-			print('', file = metadata_file)
-			print('clips = [', file = metadata_file)
-			for clip_filename in clips:
-				print('\t"{}"'.format(os.path.relpath(clip_filename, current_data_dir)), file = metadata_file)
-			print(']', file = metadata_file)
-			print('', file = metadata_file)
+	# Write our metadata file
+	with open(os.path.join(current_data_dir, 'metadata.sjson'), 'w') as metadata_file:
+		print('configs = [', file = metadata_file)
+		for config_filename in configs:
+			print('\t"{}"'.format(os.path.relpath(config_filename, config_dir)), file = metadata_file)
+		print(']', file = metadata_file)
+		print('', file = metadata_file)
+		print('clips = [', file = metadata_file)
+		for clip_filename in clips:
+			print('\t"{}"'.format(os.path.relpath(clip_filename, current_data_dir)), file = metadata_file)
+		print(']', file = metadata_file)
+		print('', file = metadata_file)
 
 	return current_data_dir
 

--- a/tools/acl_compressor/acl_compressor.py
+++ b/tools/acl_compressor/acl_compressor.py
@@ -357,7 +357,7 @@ def compress_clips(options):
 			cmd_queue.put(None)
 
 		result_queue = queue.Queue()
-		compression_start_time = time.clock()
+		compression_start_time = time.perf_counter()
 
 		threads = [ threading.Thread(target = run_acl_compressor, args = (cmd_queue, result_queue)) for _i in range(options['num_threads']) ]
 		for thread in threads:
@@ -385,7 +385,7 @@ def compress_clips(options):
 		except KeyboardInterrupt:
 			sys.exit(1)
 
-		compression_end_time = time.clock()
+		compression_end_time = time.perf_counter()
 		print()
 		print('Compressed {} clips in {}'.format(len(stat_files), format_elapsed_time(compression_end_time - compression_start_time)))
 
@@ -662,7 +662,7 @@ if __name__ == "__main__":
 
 	csv_data = create_csv(options)
 
-	aggregating_start_time = time.clock()
+	aggregating_start_time = time.perf_counter()
 
 	stat_queue = multiprocessing.Queue()
 	for stat_filename in stat_files:
@@ -712,7 +712,7 @@ if __name__ == "__main__":
 
 	write_csv(csv_data, agg_run_stats)
 
-	aggregating_end_time = time.clock()
+	aggregating_end_time = time.perf_counter()
 	print()
 	print('Found {} runs in {}'.format(num_runs, format_elapsed_time(aggregating_end_time - aggregating_start_time)))
 	print()

--- a/tools/acl_decompressor/acl_decompressor.py
+++ b/tools/acl_decompressor/acl_decompressor.py
@@ -316,7 +316,7 @@ def decompress_clips(options):
 			cmd_queue.put(None)
 
 		result_queue = queue.Queue()
-		decompression_start_time = time.clock()
+		decompression_start_time = time.perf_counter()
 
 		threads = [ threading.Thread(target = run_acl_decompressor, args = (cmd_queue, result_queue)) for _i in range(options['num_threads']) ]
 		for thread in threads:
@@ -342,7 +342,7 @@ def decompress_clips(options):
 		except KeyboardInterrupt:
 			sys.exit(1)
 
-		decompression_end_time = time.clock()
+		decompression_end_time = time.perf_counter()
 		print()
 		print('Compressed {} clips in {}'.format(len(stat_files), format_elapsed_time(decompression_end_time - decompression_start_time)))
 
@@ -428,7 +428,7 @@ if __name__ == "__main__":
 
 	csv_data = create_csv(options)
 
-	aggregating_start_time = time.clock()
+	aggregating_start_time = time.perf_counter()
 
 	stat_queue = multiprocessing.Queue()
 	for stat_filename in stat_files:
@@ -470,7 +470,7 @@ if __name__ == "__main__":
 
 	num_runs = agg_job_results['num_runs']
 
-	aggregating_end_time = time.clock()
+	aggregating_end_time = time.perf_counter()
 	print()
 	print('Found {} runs in {}'.format(num_runs, format_elapsed_time(aggregating_end_time - aggregating_start_time)))
 	print()

--- a/tools/graph_generation/gen_full_error_stats.py
+++ b/tools/graph_generation/gen_full_error_stats.py
@@ -46,9 +46,9 @@ if __name__ == "__main__":
 
 	for entry in input_sjson_data['inputs']:
 		print('Parsing {} ...'.format(entry['header']))
-		parsing_start_time = time.clock();
+		parsing_start_time = time.perf_counter();
 		csv_data = numpy.loadtxt(entry['file'], delimiter=',', dtype=input_data_type_def, skiprows=1, usecols=columns_to_extract)
-		parsing_end_time = time.clock();
+		parsing_end_time = time.perf_counter();
 		print('Parsed {} ({}) rows in {}'.format(entry['header'], len(csv_data['errors']), format_elapsed_time(parsing_end_time - parsing_start_time)))
 
 		percentiles = numpy.percentile(csv_data['errors'], desired_percentiles)


### PR DESCRIPTION
Because we might be adding or removing configs, we need to generate the metadata file everytime.
time.clock() is deprecated in python 3.3, switching to time.perf_counter() instead.
Fix processor count detection to be cross-platform.

Fixes #197
Fixes #196