### PR TITLE
perf(compression): re-use the quantization context

### DIFF
--- a/tools/acl_compressor/acl_compressor.py
+++ b/tools/acl_compressor/acl_compressor.py
@@ -737,7 +737,7 @@ if __name__ == "__main__":
 	total_duration = sum([x['total_duration'] for x in agg_run_stats.values()])
 
 	print('Sum of clip durations: {}'.format(format_elapsed_time(total_duration)))
-	print('Total compression time: {}'.format(format_elapsed_time(total_wall_compression_time)))
+	print('Total compression time: {} ({:.3f} seconds)'.format(format_elapsed_time(total_wall_compression_time), total_wall_compression_time))
 	print('Total raw size: {:.2f} MB'.format(bytes_to_mb(total_raw_size)))
 	print('Compression speed: {:.2f} KB/sec'.format(bytes_to_kb(total_raw_size) / total_compression_time))
 	if len(agg_job_results['bone_error_values']) > 0:

--- a/tools/acl_compressor/main_generic/CMakeLists.txt
+++ b/tools/acl_compressor/main_generic/CMakeLists.txt
@@ -10,7 +10,9 @@ include_directories("${PROJECT_SOURCE_DIR}/../includes")
 # Grab all of our common source files
 file(GLOB_RECURSE ALL_COMMON_SOURCE_FILES LIST_DIRECTORIES false
 	${PROJECT_SOURCE_DIR}/../includes/*.h
-	${PROJECT_SOURCE_DIR}/../sources/*.cpp)
+	${PROJECT_SOURCE_DIR}/../sources/*.cpp
+	${PROJECT_SOURCE_DIR}/../*.py
+	${PROJECT_SOURCE_DIR}/../*.md)
 
 create_source_groups("${ALL_COMMON_SOURCE_FILES}" ${PROJECT_SOURCE_DIR}/..)
 

--- a/tools/acl_decompressor/main_generic/CMakeLists.txt
+++ b/tools/acl_decompressor/main_generic/CMakeLists.txt
@@ -17,7 +17,9 @@ create_source_groups("${ALL_COMMON_SOURCE_FILES}" ${PROJECT_SOURCE_DIR}/..)
 
 # Grab all of our main source files
 file(GLOB_RECURSE ALL_MAIN_SOURCE_FILES LIST_DIRECTORIES false
-	${PROJECT_SOURCE_DIR}/*.cpp)
+	${PROJECT_SOURCE_DIR}/*.cpp
+	${PROJECT_SOURCE_DIR}/../*.py
+	${PROJECT_SOURCE_DIR}/../*.md)
 
 create_source_groups("${ALL_MAIN_SOURCE_FILES}" ${PROJECT_SOURCE_DIR})
 


### PR DESCRIPTION
There is no need to re-create and destroy the quantization context for every segment.
Re-using it saves us from allocating and freeing memory for every segment.

Add python and markdown files to solution for easier editing.
Add total elapsed time in seconds.

Fixes #198