### PR TITLE
feat(compression): add support for multiple root bones

### DIFF
--- a/docs/creating_a_skeleton.md
+++ b/docs/creating_a_skeleton.md
@@ -1,6 +1,6 @@
 # Creating a rigid skeleton
 
-After you have found an [allocator instance](implementing_an_allocator.md) to use, you will need to create a `RigidSkeleton` instance. A skeleton is a tree made up of several bones. At the root lies a single bone with no parent. Each bone that follows can have any number of children but a single parent. You will only need a few things per bone:
+After you have found an [allocator instance](implementing_an_allocator.md) to use, you will need to create a `RigidSkeleton` instance. A skeleton is a tree made up of several bones. At the root lies at least one bone with no parent. Each bone that follows can have any number of children but a single parent. You will only need a few things per bone:
 
 *  A virtual vertex distance
 *  A parent bone index

--- a/make.py
+++ b/make.py
@@ -10,7 +10,7 @@ import time
 import zipfile
 
 # The current test/decompression data version in use
-current_test_data = 'test_data_v1'
+current_test_data = 'test_data_v2'
 current_decomp_data = 'decomp_data_v4'
 
 def parse_argv():

--- a/test_data/README.md
+++ b/test_data/README.md
@@ -6,7 +6,8 @@ This directory is to contain all the relevant data to perform regression testing
 
 Find the latest test data zip file located on Google Drive and save it into this directory. If your data ever becomes stale, the python script will indicate as such and you will need to perform this step again. The zip file contains a number of clips from the [Carnegie-Mellon University](../docs/cmu_performance.md) database that were hand selected. A readme file within the zip file details this.
 
-*  **v1** Test data [link](https://drive.google.com/open?id=1psNO0riJ6RlD5_vsvPh2vPsgEBvLN3Hr) (**Latest**)
+*  **v1** Test data [link](https://drive.google.com/open?id=1psNO0riJ6RlD5_vsvPh2vPsgEBvLN3Hr)
+*  **v2** Test data [link](https://drive.google.com/open?id=192CWjNRwlskgdqakNI-k8dv-EefXwxtU) (**Latest**)
 
 ## Running the tests
 

--- a/tools/format_reference.acl.sjson
+++ b/tools/format_reference.acl.sjson
@@ -117,7 +117,7 @@ bones =
 		// Bone name
 		name = "root"
 
-		// Parent bone. An empty string denotes the root bone, there can be only one root bone
+		// Parent bone. An empty string denotes the root bone, there can be multiple root bones
 		// There must be a root bone
 		// Parent bones must be listed before their children
 		parent = ""


### PR DESCRIPTION
There is no inherent reason to limit the number of root bones to one.
Rigid body simulations might want to leverage this for optimal packing.

Fixes #187