### PR TITLE
feat(quat): optimize quat_mul for SSE2 by using XOR to flip the sign bit

### DIFF
--- a/includes/acl/math/scalar_32.h
+++ b/includes/acl/math/scalar_32.h
@@ -81,6 +81,11 @@ namespace acl
 #endif
 	}
 
+#if _MSC_VER >= 1920 && defined(_M_X64) && defined(ACL_SSE2_INTRINSICS) && !defined(ACL_AVX_INTRINSICS)
+	// HACK!!! Visual Studio 2019 has a code generation bug triggered by the code below, disable optimizations for now
+	// Bug only happens with x64 SSE2, not with AVX nor with x86
+	#pragma optimize("", off)
+#endif
 	inline float sqrt_reciprocal(float input)
 	{
 #if defined(ACL_SSE2_INTRINSICS)
@@ -105,6 +110,10 @@ namespace acl
 		return 1.0f / sqrt(input);
 #endif
 	}
+#if _MSC_VER >= 1920 && defined(_M_X64) && defined(ACL_SSE2_INTRINSICS) && !defined(ACL_AVX_INTRINSICS)
+	// HACK!!! See comment above
+	#pragma optimize("", on)
+#endif
 
 	inline float reciprocal(float input)
 	{

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.projectKey=nfrechette_acl
 sonar.projectName=Animation Compression Library
 sonar.projectVersion=1.2.1
 
-sonar.sources=includes
+sonar.sources=includes,tests/sources,tests/main_generic,tools/acl_compressor/sources,tools/acl_compressor/main_generic,tools/acl_decompressor/main_generic
 
 sonar.cfamily.build-wrapper-output=bw_output


### PR DESCRIPTION
See [here](https://github.com/nfrechette/rtm/issues/29) for details.
Also fix VS2019 code gen bug and sonar cloud.