### PR TITLE
refactor: remove release() pattern from the decompression context

### DIFF
--- a/includes/acl/algorithm/uniformly_sampled/decoder.h
+++ b/includes/acl/algorithm/uniformly_sampled/decoder.h
@@ -314,6 +314,10 @@ namespace acl
 
 			// The static settings used to strip out code at runtime
 			DecompressionSettingsType m_settings;
+
+			// Ensure we have non-zero padding to avoid compiler warnings
+			static constexpr size_t k_padding_size = alignof(acl_impl::DecompressionContext) - sizeof(DecompressionSettingsType);
+			uint8_t m_padding[k_padding_size != 0 ? k_padding_size : alignof(acl_impl::DecompressionContext)];
 		};
 
 		//////////////////////////////////////////////////////////////////////////

--- a/includes/acl/compression/impl/write_decompression_stats.h
+++ b/includes/acl/compression/impl/write_decompression_stats.h
@@ -332,7 +332,7 @@ namespace acl
 				write_decompression_performance_stats(allocator, compressed_clips, contexts, logging, writer);
 
 				for (uint32_t pass_index = 0; pass_index < k_num_decompression_evaluations; ++pass_index)
-					contexts[pass_index]->release();
+					deallocate_type(allocator, contexts[pass_index]);
 
 				for (uint32_t clip_index = 0; clip_index < k_num_decompression_evaluations; ++clip_index)
 					allocator.deallocate(compressed_clips[clip_index], compressed_clip.get_size());

--- a/includes/acl/decompression/decompress.h
+++ b/includes/acl/decompression/decompress.h
@@ -149,6 +149,10 @@ namespace acl
 		// The static settings used to strip out code at runtime
 		decompression_settings_type m_settings;
 
+		// Ensure we have non-zero padding to avoid compiler warnings
+		static constexpr size_t k_padding_size = alignof(acl_impl::persistent_decompression_context) - sizeof(decompression_settings_type);
+		uint8_t m_padding[k_padding_size != 0 ? k_padding_size : alignof(acl_impl::persistent_decompression_context)];
+
 		static_assert(std::is_base_of<decompression_settings, decompression_settings_type>::value, "decompression_settings_type must derive from decompression_settings!");
 	};
 


### PR DESCRIPTION
It can lead to warnings with GCC and it isn't consistent with anything else within ACL.