### PR TITLE
chore: add support for clang with VS2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Much thought was put into designing the library for it to be as flexible and pow
 ## Supported platforms
 
 *  Windows VS2015 x86 and x64
-*  Windows VS2017/2019 x86, x64, and ARM64*
+*  Windows (VS2017, VS2019) x86, x64, and ARM64*
+*  Windows VS2019 with clang9 x86 and x64
 *  Linux (gcc5, gcc6, gcc7, gcc8, gcc9) x86 and x64
 *  Linux (clang4, clang5, clang6, clang7, clang8, clang9) x86 and x64
 *  OS X (Xcode 8.3, 9.4, 10.3) x86 and x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,15 @@
 version: 1.3.0.{build}
 
 environment:
-  PYTHON: "C:\\Python36-x64"
+  PYTHON: "C:\\Python36-x64\\python.exe"
+  matrix:
+    - toolchain: msvc
+    - toolchain: clang
 
 image:
-- Visual Studio 2015
-- Visual Studio 2017
-- Visual Studio 2019
+  - Visual Studio 2015
+  - Visual Studio 2017
+  - Visual Studio 2019
 
 configuration:
   - Debug
@@ -21,6 +24,13 @@ matrix:
   exclude:
     - image: Visual Studio 2015
       platform: arm64
+    - image: Visual Studio 2015
+      toolchain: clang
+    - image: Visual Studio 2017
+      toolchain: clang
+    - image: Visual Studio 2019
+      platform: arm64
+      toolchain: clang
 
 install:
 - cmd: >-
@@ -28,16 +38,4 @@ install:
 
 build_script:
 - cmd: >-
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (SET COMPILER=vs2015)
-
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (SET COMPILER=vs2017)
-
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (SET COMPILER=vs2019)
-
-    SET UNIT_TEST_FLAG=-unit_test
-
-    IF "%platform%"=="arm64" (SET "UNIT_TEST_FLAG= ")
-
-    %PYTHON%\\python.exe make.py -build %UNIT_TEST_FLAG% -compiler %COMPILER% -config %configuration% -cpu %platform% -clean
-
-    %PYTHON%\\python.exe make.py -build %UNIT_TEST_FLAG% -compiler %COMPILER% -config %configuration% -cpu %platform% -nosimd
+    .\tools\appveyor_ci.bat "%APPVEYOR_BUILD_WORKER_IMAGE%" %platform% %configuration% %toolchain% "%PYTHON%"

--- a/includes/acl/core/bit_manip_utils.h
+++ b/includes/acl/core/bit_manip_utils.h
@@ -43,7 +43,9 @@
 	#include <nmmintrin.h>
 #endif
 
-#if defined(RTM_AVX_INTRINSICS)
+// Note: It seems that the Clang toolchain with MSVC enables BMI only with AVX2 unlike
+// MSVC which enables it with AVX
+#if defined(RTM_AVX_INTRINSICS) && !(defined(_MSC_VER) && defined(__clang__))
 	// Use BMI
 	#include <ammintrin.h>		// MSVC uses this header for _andn_u32 BMI intrinsic
 	#include <immintrin.h>		// Intel documentation says _andn_u32 and others are here

--- a/includes/acl/core/impl/compiler_utils.h
+++ b/includes/acl/core/impl/compiler_utils.h
@@ -38,7 +38,7 @@
 // To do this, every header is wrapped in two macros to push and pop the necessary
 // pragmas.
 //////////////////////////////////////////////////////////////////////////
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 	#define ACL_IMPL_FILE_PRAGMA_PUSH \
 		/* Disable fast math, it can hurt precision for little to no performance gain due to the high level of hand tuned optimizations. */ \
 		__pragma(float_control(precise, on, push))
@@ -54,7 +54,7 @@
 // In some cases, for performance reasons, we wish to disable stack security
 // check cookies. This macro serves this purpose.
 //////////////////////////////////////////////////////////////////////////
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 	#define ACL_DISABLE_SECURITY_COOKIE_CHECK __declspec(safebuffers)
 #else
 	#define ACL_DISABLE_SECURITY_COOKIE_CHECK

--- a/make.py
+++ b/make.py
@@ -27,7 +27,7 @@ def parse_argv():
 	actions.add_argument('-regression_test', action='store_true')
 
 	target = parser.add_argument_group(title='Target')
-	target.add_argument('-compiler', choices=['vs2015', 'vs2017', 'vs2019', 'android', 'clang4', 'clang5', 'clang6', 'clang7', 'clang8', 'clang9', 'gcc5', 'gcc6', 'gcc7', 'gcc8', 'gcc9', 'osx', 'ios'], help='Defaults to the host system\'s default compiler')
+	target.add_argument('-compiler', choices=['vs2015', 'vs2017', 'vs2019', 'vs2019-clang', 'android', 'clang4', 'clang5', 'clang6', 'clang7', 'clang8', 'clang9', 'gcc5', 'gcc6', 'gcc7', 'gcc8', 'gcc9', 'osx', 'ios'], help='Defaults to the host system\'s default compiler')
 	target.add_argument('-config', choices=['Debug', 'Release'], type=str.capitalize)
 	target.add_argument('-cpu', choices=['x86', 'x64', 'arm64'], help='Only supported for Windows, OS X, and Linux; defaults to the host system\'s architecture')
 
@@ -123,7 +123,7 @@ def get_generator(compiler, cpu):
 				# VS2017 ARM/ARM64 support only works with cmake 3.13 and up and the architecture must be specified with
 				# the -A cmake switch
 				return 'Visual Studio 15 2017'
-		elif compiler == 'vs2019':
+		elif compiler == 'vs2019' or compiler == 'vs2019-clang':
 			return 'Visual Studio 16 2019'
 		elif compiler == 'android':
 			return 'Visual Studio 14'
@@ -145,7 +145,7 @@ def get_architecture(compiler, cpu):
 		if compiler == 'vs2017':
 			if cpu == 'arm64':
 				return 'ARM64'
-		elif compiler == 'vs2019':
+		elif compiler == 'vs2019' or compiler == 'vs2019-clang':
 			if cpu == 'x86':
 				return 'Win32'
 			else:
@@ -238,6 +238,11 @@ def do_generate_solution(cmake_exe, build_dir, cmake_script_dir, test_data_dir, 
 	if not toolchain == None:
 		extra_switches.append('-DCMAKE_TOOLCHAIN_FILE="{}"'.format(os.path.join(cmake_script_dir, toolchain)))
 
+	generator_suffix = ''
+	if compiler == 'vs2019-clang':
+		extra_switches.append('-T ClangCL')
+		generator_suffix = 'Clang CL'
+
 	if test_data_dir:
 		extra_switches.append('-DTEST_DATA_DIR:STRING="{}"'.format(test_data_dir))
 
@@ -251,7 +256,7 @@ def do_generate_solution(cmake_exe, build_dir, cmake_script_dir, test_data_dir, 
 	if cmake_generator == None:
 		print('Using default generator')
 	else:
-		print('Using generator: {}'.format(cmake_generator))
+		print('Using generator: {} {}'.format(cmake_generator, generator_suffix))
 		cmake_cmd += ' -G "{}"'.format(cmake_generator)
 
 	cmake_arch = get_architecture(compiler, cpu)

--- a/tools/appveyor_ci.bat
+++ b/tools/appveyor_ci.bat
@@ -1,0 +1,53 @@
+@echo off
+
+REM Unpack arguments
+SET WORKER_IMAGE=%1
+SET PLATFORM=%2
+SET CONFIG=%3
+SET TOOLCHAIN=%4
+SET PYTHON_PATH=%5
+
+echo Worker image: %WORKER_IMAGE%
+echo Platform: %PLATFORM%
+echo Config: %CONFIG%
+echo Toolchain: %TOOLCHAIN%
+echo Python path: %PYTHON_PATH%
+
+REM Convert the build image and toolchain into our compiler string
+IF /i %TOOLCHAIN%==msvc GOTO :msvc
+IF /i %TOOLCHAIN%==clang GOTO :clang
+
+echo Unknown toolchain: %TOOLCHAIN%
+exit /B 1
+
+:msvc
+IF /i %WORKER_IMAGE%=="Visual Studio 2015" SET COMPILER=vs2015
+IF /i %WORKER_IMAGE%=="Visual Studio 2017" SET COMPILER=vs2017
+IF /i %WORKER_IMAGE%=="Visual Studio 2019" SET COMPILER=vs2019
+GOTO :next
+
+:clang
+IF /i %WORKER_IMAGE%=="Visual Studio 2019" SET COMPILER=vs2019-clang
+GOTO :next
+
+:next
+REM Set our switch if we need to run unit tests
+SET UNIT_TEST_FLAG=-unit_test
+IF /i %PLATFORM%==arm64 SET UNIT_TEST_FLAG=
+
+REM If PYTHON_PATH isn't set, assume it is in PATH
+IF NOT DEFINED PYTHON_PATH SET PYTHON_PATH=python.exe
+
+REM Build and run unit tests
+%PYTHON_PATH% make.py -build %UNIT_TEST_FLAG% -compiler %COMPILER% -config %CONFIG% -cpu %PLATFORM% -clean
+IF NOT %ERRORLEVEL% EQU 0 GOTO :build_failure
+
+%PYTHON_PATH% make.py -build %UNIT_TEST_FLAG% -compiler %COMPILER% -config %CONFIG% -cpu %PLATFORM% -nosimd
+IF NOT %ERRORLEVEL% EQU 0 GOTO :build_failure
+
+REM Done!
+exit /B 0
+
+:build_failure
+echo Build failed!
+exit /B 1


### PR DESCRIPTION
Split appveyor into a batch file for easier local testing.