### PR TITLE
fix(decompression): only update range_values offsets when necessary

### DIFF
--- a/includes/acl/decompression/decompress.h
+++ b/includes/acl/decompression/decompress.h
@@ -311,6 +311,7 @@ namespace acl
 						const rtm::scalarf range_extent = rtm::scalar_load(range_values + 1);
 						value0 = rtm::scalar_mul_add(value0, range_extent, range_min);
 						value1 = rtm::scalar_mul_add(value1, range_extent, range_min);
+						range_values += 2;
 					}
 
 					value = rtm::scalar_lerp(value0, value1, interpolation_alpha);
@@ -318,7 +319,6 @@ namespace acl
 					const uint32_t num_sample_bits = num_bits_per_component;
 					track_bit_offset0 += num_sample_bits;
 					track_bit_offset1 += num_sample_bits;
-					range_values += 2;
 				}
 
 				writer.write_float1(track_index, value);
@@ -514,7 +514,7 @@ namespace acl
 
 			if (is_constant_bit_rate(bit_rate))
 				constant_values += num_element_components;
-			else
+			else if (!is_raw_bit_rate(bit_rate))
 				range_values += num_element_components * 2;
 		}
 


### PR DESCRIPTION
When decompressing tracks, I found that the range_values were often scrambled.
I believe this is the proper fix, only increment the range_values pointer when it's not constant and not a raw_bit_rate