### PR TITLE
fix(compression): add missing sample_size copy

### DIFF
--- a/includes/acl/compression/track.h
+++ b/includes/acl/compression/track.h
@@ -264,6 +264,7 @@ namespace acl
 			out_track.m_sample_rate = m_sample_rate;
 			out_track.m_type = m_type;
 			out_track.m_category = m_category;
+			out_track.m_sample_size = m_sample_size;
 			out_track.m_desc = m_desc;
 
 			std::memcpy(out_track.m_data, m_data, m_data_size);
@@ -281,6 +282,7 @@ namespace acl
 			out_track.m_sample_rate = m_sample_rate;
 			out_track.m_type = m_type;
 			out_track.m_category = m_category;
+			out_track.m_sample_size = m_sample_size;
 			out_track.m_desc = m_desc;
 		}
 


### PR DESCRIPTION
When calling get_ref() on a track, I noticed that the range_values weren't correct and tracked it down to m_sample_size being 0.  Seemed like it was just missing from these two locations.

acl/tests/sources/io/test_reader_writer.cpp

Would demonstrate this bug, if you look at the error between the compressed and uncompressed data.