### PR TITLE
fix(compression): remove support for constant_threshold from scalar track compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Significant changes per release
 
+## 1.3.1
+
+*  Fix bug with scalar track decompression where garbage could be returned
+*  Fix scalar track quantization to properly check the resulting error
+*  Fix scalar track creation and properly copy the sample size
+*  Other minor fixes and improvements
+
 ## 1.3.0
 
 *  Added support for VS2019, GCC 9, clang7, and Xcode 11

--- a/docs/creating_a_raw_track_list.md
+++ b/docs/creating_a_raw_track_list.md
@@ -23,15 +23,13 @@ Once you have created an instance, simply populate the track data. Note that at 
 
 Each track requires a track description. It contains a number of important properties:
 
-*  **Output index**: after compression, this is the index of the track. This allows re-ordering for LOD processing and other similar use cases.
-*  **Precision**: the precision we aim to attain when optimizing the bit rate. The resulting compression error is nearly guaranteed to be below this threshold.
-*  **Constant threshold**: track with samples within this precision threshold are considered constant and can be collapsed to a single sample. *Use the same value as `Precision`, the `constant threshold` will be removed in ACL 2.0.*
+*  `output_index`: after compression, this is the index of the track. This allows re-ordering for LOD processing and other similar use cases.
+*  `precision`: the precision we aim to attain when optimizing the bit rate. The resulting compression error is nearly guaranteed to be below this threshold.
 
 ```c++
 track_desc_scalarf desc0;
 desc0.output_index = 0;
 desc0.precision = 0.001F;
-desc0.constant_threshold = 0.123F;
 ```
 
 Tracks can be created in one of four ways:

--- a/includes/acl/compression/impl/constant_track_impl.h
+++ b/includes/acl/compression/impl/constant_track_impl.h
@@ -40,7 +40,7 @@ namespace acl
 		inline bool is_scalarf_track_constant(const track& track_, const track_range& range)
 		{
 			const track_desc_scalarf& desc = track_.get_description<track_desc_scalarf>();
-			return range.is_constant(desc.constant_threshold);
+			return range.is_constant(desc.precision);
 		}
 
 		inline void extract_constant_tracks(track_list_context& context)

--- a/includes/acl/core/track_types.h
+++ b/includes/acl/core/track_types.h
@@ -169,12 +169,6 @@ namespace acl
 		// exceeding it. If the error is above the precision threshold, we will add more bits until
 		// we lower it underneath.
 		float precision;
-
-		//////////////////////////////////////////////////////////////////////////
-		// The per component precision threshold used to detect constant tracks.
-		// A constant track is a track that has a single repeating value across every sample.
-		// TODO: Use the precision?
-		float constant_threshold;
 	};
 
 #if 0	// TODO: Add support for this

--- a/includes/acl/io/clip_reader.h
+++ b/includes/acl/io/clip_reader.h
@@ -652,6 +652,7 @@ namespace acl
 				float precision;
 				m_parser.try_read("precision", precision, 0.0001F);
 
+				// Deprecated, no longer used
 				float constant_threshold;
 				m_parser.try_read("constant_threshold", constant_threshold, 0.00001F);
 
@@ -661,7 +662,6 @@ namespace acl
 				track_desc_scalarf scalar_desc;
 				scalar_desc.output_index = output_index;
 				scalar_desc.precision = precision;
-				scalar_desc.constant_threshold = constant_threshold;
 
 				if (!m_parser.array_begins("data"))
 					goto error;

--- a/includes/acl/io/clip_writer.h
+++ b/includes/acl/io/clip_writer.h
@@ -385,7 +385,6 @@ namespace acl
 					{
 						const track_float1f& track__ = track_cast<track_float1f>(track_);
 						track_writer["precision"] = track__.get_description().precision;
-						track_writer["constant_threshold"] = track__.get_description().constant_threshold;
 						track_writer["output_index"] = track__.get_description().output_index;
 
 						track_writer["data"] = [&](sjson::ArrayWriter& data_writer)
@@ -410,7 +409,6 @@ namespace acl
 					{
 						const track_float2f& track__ = track_cast<track_float2f>(track_);
 						track_writer["precision"] = track__.get_description().precision;
-						track_writer["constant_threshold"] = track__.get_description().constant_threshold;
 						track_writer["output_index"] = track__.get_description().output_index;
 
 						track_writer["data"] = [&](sjson::ArrayWriter& data_writer)
@@ -436,7 +434,6 @@ namespace acl
 					{
 						const track_float3f& track__ = track_cast<track_float3f>(track_);
 						track_writer["precision"] = track__.get_description().precision;
-						track_writer["constant_threshold"] = track__.get_description().constant_threshold;
 						track_writer["output_index"] = track__.get_description().output_index;
 
 						track_writer["data"] = [&](sjson::ArrayWriter& data_writer)
@@ -463,7 +460,6 @@ namespace acl
 					{
 						const track_float4f& track__ = track_cast<track_float4f>(track_);
 						track_writer["precision"] = track__.get_description().precision;
-						track_writer["constant_threshold"] = track__.get_description().constant_threshold;
 						track_writer["output_index"] = track__.get_description().output_index;
 
 						track_writer["data"] = [&](sjson::ArrayWriter& data_writer)
@@ -491,7 +487,6 @@ namespace acl
 					{
 						const track_vector4f& track__ = track_cast<track_vector4f>(track_);
 						track_writer["precision"] = track__.get_description().precision;
-						track_writer["constant_threshold"] = track__.get_description().constant_threshold;
 						track_writer["output_index"] = track__.get_description().output_index;
 
 						track_writer["data"] = [&](sjson::ArrayWriter& data_writer)

--- a/tests/sources/io/test_reader_writer.cpp
+++ b/tests/sources/io/test_reader_writer.cpp
@@ -312,7 +312,6 @@ TEST_CASE("sjson_track_list_reader_writer float1f", "[io]")
 	track_desc_scalarf desc0;
 	desc0.output_index = 0;
 	desc0.precision = 0.001F;
-	desc0.constant_threshold = 0.123F;
 	track_float1f track0 = track_float1f::make_reserve(desc0, allocator, num_samples, 32.0F);
 	track0[0] = 1.0F;
 	track0[1] = 2.333F;
@@ -394,7 +393,6 @@ TEST_CASE("sjson_track_list_reader_writer float1f", "[io]")
 
 		CHECK(file_track.get_description().output_index == ref_track.get_description().output_index);
 		CHECK(rtm::scalar_near_equal(file_track.get_description().precision, ref_track.get_description().precision, 1.0E-8F));
-		CHECK(rtm::scalar_near_equal(file_track.get_description().constant_threshold, ref_track.get_description().constant_threshold, 1.0E-8F));
 		CHECK(file_track.get_num_samples() == ref_track.get_num_samples());
 		CHECK(file_track.get_output_index() == ref_track.get_output_index());
 		CHECK(file_track.get_sample_rate() == ref_track.get_sample_rate());
@@ -424,7 +422,6 @@ TEST_CASE("sjson_track_list_reader_writer float2f", "[io]")
 	track_desc_scalarf desc0;
 	desc0.output_index = 0;
 	desc0.precision = 0.001F;
-	desc0.constant_threshold = 0.123F;
 	track_float2f track0 = track_float2f::make_reserve(desc0, allocator, num_samples, 32.0F);
 	track0[0] = rtm::float2f{ 1.0F, 3123.0F };
 	track0[1] = rtm::float2f{ 2.333F, 321.13F };
@@ -506,7 +503,6 @@ TEST_CASE("sjson_track_list_reader_writer float2f", "[io]")
 
 		CHECK(file_track.get_description().output_index == ref_track.get_description().output_index);
 		CHECK(rtm::scalar_near_equal(file_track.get_description().precision, ref_track.get_description().precision, 1.0E-8F));
-		CHECK(rtm::scalar_near_equal(file_track.get_description().constant_threshold, ref_track.get_description().constant_threshold, 1.0E-8F));
 		CHECK(file_track.get_num_samples() == ref_track.get_num_samples());
 		CHECK(file_track.get_output_index() == ref_track.get_output_index());
 		CHECK(file_track.get_sample_rate() == ref_track.get_sample_rate());
@@ -536,7 +532,6 @@ TEST_CASE("sjson_track_list_reader_writer float3f", "[io]")
 	track_desc_scalarf desc0;
 	desc0.output_index = 0;
 	desc0.precision = 0.001F;
-	desc0.constant_threshold = 0.123F;
 	track_float3f track0 = track_float3f::make_reserve(desc0, allocator, num_samples, 32.0F);
 	track0[0] = rtm::float3f{ 1.0F, 3123.0F, 315.13F };
 	track0[1] = rtm::float3f{ 2.333F, 321.13F, 31.66F };
@@ -618,7 +613,6 @@ TEST_CASE("sjson_track_list_reader_writer float3f", "[io]")
 
 		CHECK(file_track.get_description().output_index == ref_track.get_description().output_index);
 		CHECK(rtm::scalar_near_equal(file_track.get_description().precision, ref_track.get_description().precision, 1.0E-8F));
-		CHECK(rtm::scalar_near_equal(file_track.get_description().constant_threshold, ref_track.get_description().constant_threshold, 1.0E-8F));
 		CHECK(file_track.get_num_samples() == ref_track.get_num_samples());
 		CHECK(file_track.get_output_index() == ref_track.get_output_index());
 		CHECK(file_track.get_sample_rate() == ref_track.get_sample_rate());
@@ -648,7 +642,6 @@ TEST_CASE("sjson_track_list_reader_writer float4f", "[io]")
 	track_desc_scalarf desc0;
 	desc0.output_index = 0;
 	desc0.precision = 0.001F;
-	desc0.constant_threshold = 0.123F;
 	track_float4f track0 = track_float4f::make_reserve(desc0, allocator, num_samples, 32.0F);
 	track0[0] = rtm::float4f{ 1.0F, 3123.0F, 315.13F, 123.31F };
 	track0[1] = rtm::float4f{ 2.333F, 321.13F, 31.66F, 7154.1F };
@@ -730,7 +723,6 @@ TEST_CASE("sjson_track_list_reader_writer float4f", "[io]")
 
 		CHECK(file_track.get_description().output_index == ref_track.get_description().output_index);
 		CHECK(rtm::scalar_near_equal(file_track.get_description().precision, ref_track.get_description().precision, 1.0E-8F));
-		CHECK(rtm::scalar_near_equal(file_track.get_description().constant_threshold, ref_track.get_description().constant_threshold, 1.0E-8F));
 		CHECK(file_track.get_num_samples() == ref_track.get_num_samples());
 		CHECK(file_track.get_output_index() == ref_track.get_output_index());
 		CHECK(file_track.get_sample_rate() == ref_track.get_sample_rate());
@@ -760,7 +752,6 @@ TEST_CASE("sjson_track_list_reader_writer vector4f", "[io]")
 	track_desc_scalarf desc0;
 	desc0.output_index = 0;
 	desc0.precision = 0.001F;
-	desc0.constant_threshold = 0.123F;
 	track_vector4f track0 = track_vector4f::make_reserve(desc0, allocator, num_samples, 32.0F);
 	track0[0] = rtm::vector_set(1.0F, 3123.0F, 315.13F, 123.31F);
 	track0[1] = rtm::vector_set(2.333F, 321.13F, 31.66F, 7154.1F);
@@ -842,7 +833,6 @@ TEST_CASE("sjson_track_list_reader_writer vector4f", "[io]")
 
 		CHECK(file_track.get_description().output_index == ref_track.get_description().output_index);
 		CHECK(rtm::scalar_near_equal(file_track.get_description().precision, ref_track.get_description().precision, 1.0E-8F));
-		CHECK(rtm::scalar_near_equal(file_track.get_description().constant_threshold, ref_track.get_description().constant_threshold, 1.0E-8F));
 		CHECK(file_track.get_num_samples() == ref_track.get_num_samples());
 		CHECK(file_track.get_output_index() == ref_track.get_output_index());
 		CHECK(file_track.get_sample_rate() == ref_track.get_sample_rate());

--- a/tools/format_reference.acl.sjson
+++ b/tools/format_reference.acl.sjson
@@ -217,6 +217,7 @@ tracks =
 
 		// The constant track detection threshold
 		// Defaults to '0.00001' units
+		// DEPRECATED, NO LONGER USED OR NECESSARY
 		constant_threshold = 0.00001
 
 		// The track output index. When writing out the compressed data stream, this index


### PR DESCRIPTION
Whether a track is constant or not is an implementation detail. It does not need
to be controlled by the user. We can determine whether it should be constant
or not entirely from the precision value desired.