### PR TITLE
fix(compression): avoid crashing when compressing an empty track_array

### DIFF
--- a/includes/acl/compression/compress.h
+++ b/includes/acl/compression/compress.h
@@ -96,7 +96,7 @@ namespace acl
 		const uint32_t range_values_size = write_track_range_values(context, nullptr);
 		const uint32_t animated_num_bits = write_track_animated_values(context, nullptr);
 		const uint32_t animated_values_size = (animated_num_bits + 7) / 8;		// Round up to nearest byte
-		const uint32_t num_bits_per_frame = animated_num_bits / context.num_samples;
+		const uint32_t num_bits_per_frame = context.num_samples != 0 ? (animated_num_bits / context.num_samples) : 0;
 
 		uint32_t buffer_size = 0;
 		buffer_size += sizeof(compressed_tracks);								// Headers


### PR DESCRIPTION
Fixes #286