### PR TITLE
fix(compression): strip out compression timing when not required

### DIFF
--- a/includes/acl/compression/compress.h
+++ b/includes/acl/compression/compress.h
@@ -80,7 +80,9 @@ namespace acl
 		// and we might intentionally divide by zero, etc.
 		scope_disable_fp_exceptions fp_off;
 
+#if defined(SJSON_CPP_WRITER)
 		ScopeProfiler compression_time;
+#endif
 
 		track_list_context context;
 		initialize_context(allocator, track_list, context);
@@ -162,9 +164,9 @@ namespace acl
 		buffer_header->size = buffer_size;
 		buffer_header->hash = hash32(safe_ptr_cast<const uint8_t>(header), buffer_size - sizeof(raw_buffer_header));	// Hash everything but the raw buffer header
 
+#if defined(SJSON_CPP_WRITER)
 		compression_time.stop();
 
-#if defined(SJSON_CPP_WRITER)
 		if (out_stats.logging != StatLogging::None)
 			write_compression_stats(context, *out_compressed_tracks, compression_time, out_stats);
 #endif


### PR DESCRIPTION
This ends up pulling in code we don't always need with emscripten/WASM.