### PR TITLE
fix(compression): zero out W component of translation/scale track ranges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           path: 'emsdk-cache'
           key: ${{ runner.os }}-emsdk-1.39.11
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v4
+        uses: mymindstorm/setup-emsdk@v6
         with:
           version: 1.39.11
           no-cache: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,18 @@ if(CMAKE_CONFIGURATION_TYPES)
 	set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING "Reset the configurations to what we need" FORCE)
 endif()
 
+# Determine if we should include unit tests
+set(INCLUDE_UNIT_TESTS true)
+
+if(PLATFORM_IOS)
+	# Catch2 2.13 doesn't compile on iOS with Xcode 8 and 9
+	if(PLATFORM_XCODE_VERSION MATCHES "^8\\.")
+		set(INCLUDE_UNIT_TESTS false)
+	elseif(PLATFORM_XCODE_VERSION MATCHES "^9\\.")
+		set(INCLUDE_UNIT_TESTS false)
+	endif()
+endif()
+
 # Grab all of our include files
 file(GLOB_RECURSE ACL_INCLUDE_FILES LIST_DIRECTORIES false
 	${PROJECT_SOURCE_DIR}/includes/*.h
@@ -55,7 +67,10 @@ enable_testing()
 # Add other projects
 add_subdirectory("${PROJECT_SOURCE_DIR}/tools/acl_compressor")
 add_subdirectory("${PROJECT_SOURCE_DIR}/tools/acl_decompressor")
-add_subdirectory("${PROJECT_SOURCE_DIR}/tests")
+
+if(INCLUDE_UNIT_TESTS)
+	add_subdirectory("${PROJECT_SOURCE_DIR}/tests")
+endif()
 
 # Custom regression testing (requires SJSON support)
 if(USE_SJSON)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 image:
   - Visual Studio 2015
   - Visual Studio 2017
-  - Previous Visual Studio 2019
+  - Visual Studio 2019
 
 configuration:
   - Debug

--- a/cmake/CMakePlatforms.cmake
+++ b/cmake/CMakePlatforms.cmake
@@ -15,6 +15,15 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 		set(PLATFORM_OSX 1)
 		set(PLATFORM_NAME "OS X")
 	endif()
+
+	# Get the Xcode version being used.
+	execute_process(COMMAND xcodebuild -version
+		OUTPUT_VARIABLE PLATFORM_XCODE_VERSION
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	string(REGEX MATCH "Xcode [0-9\\.]+" PLATFORM_XCODE_VERSION "${PLATFORM_XCODE_VERSION}")
+	string(REGEX REPLACE "Xcode ([0-9\\.]+)" "\\1" PLATFORM_XCODE_VERSION "${PLATFORM_XCODE_VERSION}")
+	message(STATUS "Building with Xcode version: ${PLATFORM_XCODE_VERSION}")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 	set(PLATFORM_LINUX 1)
 	set(PLATFORM_NAME "Linux")

--- a/external/README.md
+++ b/external/README.md
@@ -10,7 +10,7 @@
 
 ### Catch2
 
-[Catch2 v2.11.0](https://github.com/catchorg/Catch2/releases/tag/v2.11.0) (Boost Software License v1.0) is used by our [unit tests](../tests). You will only need it if you run the unit tests and it is included as-is without modifications.
+[Catch2 v2.13.1](https://github.com/catchorg/Catch2/releases/tag/v2.13.1) (Boost Software License v1.0) is used by our [unit tests](../tests). You will only need it if you run the unit tests and it is included as-is without modifications.
 
 ### sjson-cpp
 

--- a/includes/acl/compression/impl/normalize_streams.h
+++ b/includes/acl/compression/impl/normalize_streams.h
@@ -43,7 +43,7 @@ namespace acl
 {
 	namespace acl_impl
 	{
-		inline TrackStreamRange calculate_track_range(const TrackStream& stream)
+		inline TrackStreamRange calculate_track_range(const TrackStream& stream, bool is_vector4)
 		{
 			rtm::vector4f min = rtm::vector_set(1e10F);
 			rtm::vector4f max = rtm::vector_set(-1e10F);
@@ -55,6 +55,13 @@ namespace acl
 
 				min = rtm::vector_min(min, sample);
 				max = rtm::vector_max(max, sample);
+			}
+
+			// Set the 4th component to zero if we don't need it
+			if (!is_vector4)
+			{
+				min = rtm::vector_set_w(min, 0.0F);
+				max = rtm::vector_set_w(max, 0.0F);
 			}
 
 			return TrackStreamRange::from_min_max(min, max);
@@ -69,11 +76,11 @@ namespace acl
 				const BoneStreams& bone_stream = segment.bone_streams[bone_index];
 				BoneRanges& bone_range = bone_ranges[bone_index];
 
-				bone_range.rotation = calculate_track_range(bone_stream.rotations);
-				bone_range.translation = calculate_track_range(bone_stream.translations);
+				bone_range.rotation = calculate_track_range(bone_stream.rotations, true);
+				bone_range.translation = calculate_track_range(bone_stream.translations, false);
 
 				if (has_scale)
-					bone_range.scale = calculate_track_range(bone_stream.scales);
+					bone_range.scale = calculate_track_range(bone_stream.scales, false);
 				else
 					bone_range.scale = TrackStreamRange();
 			}


### PR DESCRIPTION
When we check for constant tracks, we use the full vector4 which is fine
for rotations but it could contain garbage for translation/scale.