### PR TITLE
feat: improved bind pose handling

### DIFF
--- a/includes/acl/compression/impl/compact_constant_streams.h
+++ b/includes/acl/compression/impl/compact_constant_streams.h
@@ -90,6 +90,13 @@ namespace acl
 			const uint32_t num_bones = context.num_bones;
 			const uint32_t num_samples = context.num_samples;
 			const rtm::vector4f default_scale = get_default_scale(context.additive_format);
+			
+#ifdef ACL_BIND_POSE
+
+			const bool default_bind_pose = get_default_bind_pose(context.additive_format);
+
+#endif
+			
 			uint32_t num_default_bone_scales = 0;
 
 			// When a stream is constant, we only keep the first sample
@@ -118,7 +125,17 @@ namespace acl
 
 					bone_stream.rotations = std::move(constant_stream);
 					bone_stream.is_rotation_constant = true;
+					
+#ifdef ACL_BIND_POSE
+
+					const rtm::quatf default_bind_rotation_conj = (default_bind_pose) ? rtm::quat_conjugate(desc.default_value.rotation) : rtm::quat_identity();
+					bone_stream.is_rotation_default = rtm::quat_near_identity(rtm::quat_normalize(rtm::quat_mul(rtm::vector_to_quat(rotation), default_bind_rotation_conj)), constant_rotation_threshold_angle);
+				
+#else
+					
 					bone_stream.is_rotation_default = rtm::quat_near_identity(rtm::vector_to_quat(rotation), constant_rotation_threshold_angle);
+					
+#endif
 
 					bone_range.rotation = track_stream_range::from_min_extent(rotation, rtm::vector_zero());
 				}
@@ -131,7 +148,17 @@ namespace acl
 
 					bone_stream.translations = std::move(constant_stream);
 					bone_stream.is_translation_constant = true;
+					
+#ifdef ACL_BIND_POSE
+
+					const rtm::vector4f default_bind_translation = (default_bind_pose) ? desc.default_value.translation : rtm::vector_zero();
+					bone_stream.is_translation_default = rtm::vector_all_near_equal3(translation, default_bind_translation, constant_translation_threshold);
+
+#else
+
 					bone_stream.is_translation_default = rtm::vector_all_near_equal3(translation, rtm::vector_zero(), constant_translation_threshold);
+
+#endif
 
 					bone_range.translation = track_stream_range::from_min_extent(translation, rtm::vector_zero());
 				}
@@ -144,7 +171,17 @@ namespace acl
 
 					bone_stream.scales = std::move(constant_stream);
 					bone_stream.is_scale_constant = true;
+					
+#ifdef ACL_BIND_POSE
+
+					const rtm::vector4f default_bind_scale = (default_bind_pose) ? desc.default_value.scale : default_scale;
+					bone_stream.is_scale_default = rtm::vector_all_near_equal3(scale, default_bind_scale, constant_scale_threshold);
+
+#else
+
 					bone_stream.is_scale_default = rtm::vector_all_near_equal3(scale, default_scale, constant_scale_threshold);
+					
+#endif
 
 					bone_range.scale = track_stream_range::from_min_extent(scale, rtm::vector_zero());
 

--- a/includes/acl/compression/impl/compress.transform.impl.h
+++ b/includes/acl/compression/impl/compress.transform.impl.h
@@ -296,6 +296,12 @@ namespace acl
 			header->set_has_database(false);
 			header->set_has_metadata(metadata_size != 0);
 
+#ifdef ACL_BIND_POSE
+
+			header->set_default_bind_pose(!is_additive);
+
+#endif
+
 			// Write our transform tracks header
 			transform_tracks_header* transforms_header = safe_ptr_cast<transform_tracks_header>(buffer);
 			buffer += sizeof(transform_tracks_header);

--- a/includes/acl/compression/impl/convert.impl.h
+++ b/includes/acl/compression/impl/convert.impl.h
@@ -148,6 +148,15 @@ namespace acl
 
 			acl_impl::debug_track_writer writer(allocator, track_type, num_tracks);
 
+#ifdef ACL_BIND_POSE
+
+			if(track_type == track_type8::qvvf)
+			{
+				writer.initialize_bind_pose(result);
+			}
+
+#endif
+
 			for (uint32_t sample_index = 0; sample_index < num_samples; ++sample_index)
 			{
 				const float sample_time = rtm::scalar_min(float(sample_index) / sample_rate, duration);
@@ -194,6 +203,15 @@ namespace acl
 			context.initialize(tracks);
 
 			acl_impl::debug_track_writer writer(allocator, track_type, num_tracks);
+
+#ifdef ACL_BIND_POSE
+
+			if(track_type == track_type8::qvvf)
+			{
+				writer.initialize_bind_pose(result);
+			}
+
+#endif
 
 			for (uint32_t sample_index = 0; sample_index < num_samples; ++sample_index)
 			{

--- a/includes/acl/compression/impl/sample_streams.h
+++ b/includes/acl/compression/impl/sample_streams.h
@@ -568,6 +568,14 @@ namespace acl
 
 		struct sample_context
 		{
+
+#ifdef ACL_BIND_POSE
+
+			explicit sample_context(bool in_use_default_value) : use_default_value(in_use_default_value) {}
+			bool use_default_value;
+
+#endif
+
 			uint32_t track_index;
 
 			uint32_t sample_key;
@@ -610,7 +618,17 @@ namespace acl
 		{
 			rtm::quatf rotation;
 			if (bone_stream.is_rotation_default)
+
+#ifdef ACL_BIND_POSE
+
+				rotation = (context.use_default_value)? bone_stream.default_value.rotation: rtm::quat_identity();
+
+#else
+
 				rotation = rtm::quat_identity();
+		
+#endif
+
 			else if (bone_stream.is_rotation_constant)
 				rotation = rtm::quat_normalize(get_rotation_sample(bone_stream, 0));
 			else
@@ -626,7 +644,17 @@ namespace acl
 		{
 			rtm::quatf rotation;
 			if (bone_stream.is_rotation_default)
+
+#ifdef ACL_BIND_POSE
+
+				rotation = (context.use_default_value)? bone_stream.default_value.rotation: rtm::quat_identity();
+
+#else
+
 				rotation = rtm::quat_identity();
+
+#endif
+
 			else if (bone_stream.is_rotation_constant)
 			{
 				if (is_rotation_variable)
@@ -652,7 +680,17 @@ namespace acl
 		RTM_FORCE_INLINE rtm::vector4f RTM_SIMD_CALL sample_translation(const sample_context& context, const transform_streams& bone_stream)
 		{
 			if (bone_stream.is_translation_default)
+
+#ifdef ACL_BIND_POSE
+
+				return (context.use_default_value) ? bone_stream.default_value.translation : rtm::vector_zero();
+
+#else
+
 				return rtm::vector_zero();
+
+#endif
+
 			else if (bone_stream.is_translation_constant)
 				return get_translation_sample(bone_stream, 0);
 			else
@@ -662,7 +700,17 @@ namespace acl
 		RTM_FORCE_INLINE rtm::vector4f RTM_SIMD_CALL sample_translation(const sample_context& context, const transform_streams& bone_stream, const transform_streams& raw_bone_stream, bool is_translation_variable, vector_format8 translation_format)
 		{
 			if (bone_stream.is_translation_default)
+
+#ifdef ACL_BIND_POSE
+
+				return (context.use_default_value) ? bone_stream.default_value.translation : rtm::vector_zero();
+
+#else
+
 				return rtm::vector_zero();
+
+#endif
+
 			else if (bone_stream.is_translation_constant)
 				return get_translation_sample(raw_bone_stream, 0, vector_format8::vector3f_full);
 			else if (is_translation_variable)
@@ -674,7 +722,17 @@ namespace acl
 		RTM_FORCE_INLINE rtm::vector4f RTM_SIMD_CALL sample_scale(const sample_context& context, const transform_streams& bone_stream, rtm::vector4f_arg0 default_scale)
 		{
 			if (bone_stream.is_scale_default)
+
+#ifdef ACL_BIND_POSE
+
+				return (context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
 				return default_scale;
+
+#endif
+
 			else if (bone_stream.is_scale_constant)
 				return get_scale_sample(bone_stream, 0);
 			else
@@ -684,7 +742,17 @@ namespace acl
 		RTM_FORCE_INLINE rtm::vector4f RTM_SIMD_CALL sample_scale(const sample_context& context, const transform_streams& bone_stream, const transform_streams& raw_bone_stream, bool is_scale_variable, vector_format8 scale_format, rtm::vector4f_arg0 default_scale)
 		{
 			if (bone_stream.is_scale_default)
+
+#ifdef ACL_BIND_POSE
+
+				return (context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
 				return default_scale;
+
+#endif
+
 			else if (bone_stream.is_scale_constant)
 				return get_scale_sample(raw_bone_stream, 0, vector_format8::vector3f_full);
 			else if (is_scale_variable)
@@ -702,7 +770,16 @@ namespace acl
 			// With uniform sample distributions, we do not interpolate.
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			acl_impl::sample_context context(get_default_bind_pose(segment_context->clip->additive_format));
+
+#else
+
 			acl_impl::sample_context context;
+
+#endif
+
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
 
@@ -714,7 +791,17 @@ namespace acl
 
 				const rtm::quatf rotation = acl_impl::sample_rotation(context, bone_stream);
 				const rtm::vector4f translation = acl_impl::sample_translation(context, bone_stream);
-				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, default_scale) : default_scale;
+				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, default_scale) :
+
+#ifdef ACL_BIND_POSE
+
+				(context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
+				default_scale;
+
+#endif
 
 				out_local_pose[bone_index] = rtm::qvv_set(rotation, translation, scale);
 			}
@@ -731,7 +818,16 @@ namespace acl
 			// With uniform sample distributions, we do not interpolate.
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			acl_impl::sample_context context(get_default_bind_pose(segment_context->clip->additive_format));
+
+#else
+
 			acl_impl::sample_context context;
+
+#endif
+
 			context.track_index = bone_index;
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
@@ -740,7 +836,17 @@ namespace acl
 
 			const rtm::quatf rotation = acl_impl::sample_rotation(context, bone_stream);
 			const rtm::vector4f translation = acl_impl::sample_translation(context, bone_stream);
-			const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, default_scale) : default_scale;
+			const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, default_scale) :
+
+#ifdef ACL_BIND_POSE
+
+				(context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
+				default_scale;
+
+#endif
 
 			out_local_pose[bone_index] = rtm::qvv_set(rotation, translation, scale);
 		}
@@ -756,7 +862,16 @@ namespace acl
 			// With uniform sample distributions, we do not interpolate.
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			acl_impl::sample_context context(get_default_bind_pose(segment_context->clip->additive_format));
+
+#else
+
 			acl_impl::sample_context context;
+
+#endif
+
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
 
@@ -769,7 +884,17 @@ namespace acl
 
 				const rtm::quatf rotation = acl_impl::sample_rotation(context, bone_stream);
 				const rtm::vector4f translation = acl_impl::sample_translation(context, bone_stream);
-				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, default_scale) : default_scale;
+				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, default_scale) :
+
+#ifdef ACL_BIND_POSE
+
+				(context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
+				default_scale;
+
+#endif
 
 				out_local_pose[current_bone_index] = rtm::qvv_set(rotation, translation, scale);
 				current_bone_index = bone_stream.parent_bone_index;
@@ -789,7 +914,16 @@ namespace acl
 			// With uniform sample distributions, we do not interpolate.
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			acl_impl::sample_context context(get_default_bind_pose(segment_context->clip->additive_format));
+
+#else
+
 			acl_impl::sample_context context;
+
+#endif
+
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
 
@@ -803,7 +937,17 @@ namespace acl
 
 				const rtm::quatf rotation = acl_impl::sample_rotation(context, bone_stream, raw_bone_steam, is_rotation_variable, rotation_format);
 				const rtm::vector4f translation = acl_impl::sample_translation(context, bone_stream, raw_bone_steam, is_translation_variable, translation_format);
-				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, raw_bone_steam, is_scale_variable, scale_format, default_scale) : default_scale;
+				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, raw_bone_steam, is_scale_variable, scale_format, default_scale) :
+
+#ifdef ACL_BIND_POSE
+
+				(context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
+				default_scale;
+
+#endif
 
 				out_local_pose[bone_index] = rtm::qvv_set(rotation, translation, scale);
 			}
@@ -824,7 +968,16 @@ namespace acl
 			// With uniform sample distributions, we do not interpolate.
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			acl_impl::sample_context context(get_default_bind_pose(segment_context->clip->additive_format));
+
+#else
+
 			acl_impl::sample_context context;
+
+#endif
+
 			context.track_index = bone_index;
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
@@ -835,7 +988,17 @@ namespace acl
 
 			const rtm::quatf rotation = acl_impl::sample_rotation(context, bone_stream, raw_bone_stream, is_rotation_variable, rotation_format);
 			const rtm::vector4f translation = acl_impl::sample_translation(context, bone_stream, raw_bone_stream, is_translation_variable, translation_format);
-			const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, raw_bone_stream, is_scale_variable, scale_format, default_scale) : default_scale;
+			const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, raw_bone_stream, is_scale_variable, scale_format, default_scale) :
+
+#ifdef ACL_BIND_POSE
+
+				(context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
+				default_scale;
+
+#endif
 
 			out_local_pose[bone_index] = rtm::qvv_set(rotation, translation, scale);
 		}
@@ -855,7 +1018,16 @@ namespace acl
 			// With uniform sample distributions, we do not interpolate.
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			acl_impl::sample_context context(get_default_bind_pose(segment_context->clip->additive_format));
+
+#else
+
 			acl_impl::sample_context context;
+
+#endif
+
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
 
@@ -870,7 +1042,17 @@ namespace acl
 
 				const rtm::quatf rotation = acl_impl::sample_rotation(context, bone_stream, raw_bone_stream, is_rotation_variable, rotation_format);
 				const rtm::vector4f translation = acl_impl::sample_translation(context, bone_stream, raw_bone_stream, is_translation_variable, translation_format);
-				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, raw_bone_stream, is_scale_variable, scale_format, default_scale) : default_scale;
+				const rtm::vector4f scale = has_scale ? acl_impl::sample_scale(context, bone_stream, raw_bone_stream, is_scale_variable, scale_format, default_scale) :
+
+#ifdef ACL_BIND_POSE
+
+				(context.use_default_value) ? bone_stream.default_value.scale : default_scale;
+
+#else
+
+				default_scale;
+
+#endif
 
 				out_local_pose[current_bone_index] = rtm::qvv_set(rotation, translation, scale);
 				current_bone_index = bone_stream.parent_bone_index;

--- a/includes/acl/compression/impl/segment_streams.h
+++ b/includes/acl/compression/impl/segment_streams.h
@@ -126,6 +126,12 @@ namespace acl
 					segment_bone_stream.bone_index = bone_index;
 					segment_bone_stream.parent_bone_index = clip_bone_stream.parent_bone_index;
 					segment_bone_stream.output_index = clip_bone_stream.output_index;
+					
+#ifdef ACL_BIND_POSE
+
+					segment_bone_stream.default_value = clip_bone_stream.default_value;
+
+#endif
 
 					if (clip_bone_stream.is_rotation_constant)
 					{

--- a/includes/acl/compression/impl/track_bit_rate_database.h
+++ b/includes/acl/compression/impl/track_bit_rate_database.h
@@ -249,6 +249,12 @@ namespace acl
 			bool				m_is_translation_variable;
 			bool				m_is_scale_variable;
 			bool				m_has_scale;
+			
+#ifdef ACL_BIND_POSE
+
+			bool				m_default_bind_pose;
+
+#endif
 
 			uint32_t			m_generation_id;
 
@@ -364,6 +370,12 @@ namespace acl
 			const bool has_scale = raw_bone_steams->segment->clip->has_scale;
 			m_has_scale = has_scale;
 			m_default_scale = get_default_scale(bone_streams->segment->clip->additive_format);
+			
+#ifdef ACL_BIND_POSE
+
+			m_default_bind_pose = get_default_bind_pose(bone_streams->segment->clip->additive_format);
+
+#endif
 
 			const uint32_t num_tracks_per_transform = has_scale ? 3 : 2;
 			const uint32_t num_entries_per_transform = num_tracks_per_transform * k_num_bit_rates_cached_per_track;
@@ -642,7 +654,17 @@ namespace acl
 
 			rtm::quatf rotation;
 			if (bone_stream.is_rotation_default)
+			
+#ifdef ACL_BIND_POSE
+
+				rotation = (m_default_bind_pose)? bone_stream.default_value.rotation: rtm::quat_identity();
+
+#else		
+			
 				rotation = rtm::quat_identity();
+				
+#endif
+				
 			else if (bone_stream.is_rotation_constant)
 			{
 				uint32_t* validity_bitset = m_track_entry_bitsets + (m_bitset_desc.get_size() * rotation_cache_index_);
@@ -722,7 +744,17 @@ namespace acl
 
 			rtm::vector4f translation;
 			if (bone_stream.is_translation_default)
+
+#ifdef ACL_BIND_POSE
+
+				translation = (m_default_bind_pose) ? bone_stream.default_value.translation : rtm::vector_zero();
+
+#else
+
 				translation = rtm::vector_zero();
+
+#endif
+
 			else if (bone_stream.is_translation_constant)
 			{
 				uint32_t* validity_bitset = m_track_entry_bitsets + (m_bitset_desc.get_size() * translation_cache_index_);
@@ -795,7 +827,17 @@ namespace acl
 
 			rtm::vector4f scale;
 			if (bone_stream.is_scale_default)
+
+#ifdef ACL_BIND_POSE
+
+				scale = (m_default_bind_pose) ? bone_stream.default_value.scale : m_default_scale;
+
+#else
+
 				scale = m_default_scale;
+
+#endif
+
 			else if (bone_stream.is_scale_constant)
 			{
 				uint32_t* validity_bitset = m_track_entry_bitsets + (m_bitset_desc.get_size() * scale_cache_index_);
@@ -871,7 +913,16 @@ namespace acl
 
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			sample_context context(m_default_bind_pose);
+
+#else
+
 			sample_context context;
+
+#endif
+
 			context.track_index = query.m_track_index;
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
@@ -894,7 +945,16 @@ namespace acl
 
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			sample_context context(m_default_bind_pose);
+
+#else
+
 			sample_context context;
+
+#endif
+
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
 
@@ -927,7 +987,16 @@ namespace acl
 
 			const uint32_t sample_key = get_uniform_sample_key(*segment_context, sample_time);
 
+#ifdef ACL_BIND_POSE
+
+			sample_context context(m_default_bind_pose);
+
+#else
+
 			sample_context context;
+
+#endif
+
 			context.sample_key = sample_key;
 			context.sample_time = sample_time;
 

--- a/includes/acl/compression/impl/track_error.impl.h
+++ b/includes/acl/compression/impl/track_error.impl.h
@@ -100,6 +100,12 @@ namespace acl
 		{
 			virtual ~ierror_calculation_adapter() = default;
 
+#ifdef ACL_BIND_POSE
+
+			virtual void initialize_bind_pose(debug_track_writer& tracks_writer0, debug_track_writer& tracks_writer1) = 0;
+
+#endif
+
 			// Scalar and transforms, mandatory
 			virtual void sample_tracks0(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) = 0;
 			virtual void sample_tracks1(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) = 0;
@@ -172,6 +178,12 @@ namespace acl
 
 			debug_track_writer tracks_writer0(allocator, track_type, num_tracks);
 			debug_track_writer tracks_writer1(allocator, track_type, num_tracks);
+			
+#ifdef ACL_BIND_POSE
+
+			ACL_ASSERT(track_type != track_type8::qvvf, "Don't use calculate_scalar_track_error on track_type8::qvvf");
+
+#endif
 
 			// Measure our error
 			for (uint32_t sample_index = 0; sample_index < num_samples; ++sample_index)
@@ -228,6 +240,13 @@ namespace acl
 
 			debug_track_writer tracks_writer0(allocator, track_type8::qvvf, num_tracks);
 			debug_track_writer tracks_writer1(allocator, track_type8::qvvf, num_tracks);
+			
+#ifdef ACL_BIND_POSE
+
+			args.adapter.initialize_bind_pose(tracks_writer0, tracks_writer1);
+
+#endif
+
 			debug_track_writer tracks_writer1_remapped(allocator, track_type8::qvvf, num_tracks);
 			debug_track_writer tracks_writer_base(allocator, track_type8::qvvf, num_tracks);
 
@@ -391,6 +410,17 @@ namespace acl
 			{
 			}
 
+#ifdef ACL_BIND_POSE
+
+			virtual void initialize_bind_pose(debug_track_writer& track_writer0, debug_track_writer& track_writer1) override
+			{
+				(void)track_writer0;
+				(void)track_writer1;
+				ACL_ASSERT(false, "Unreachable code.");
+			}
+
+#endif
+
 			virtual void sample_tracks0(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) override
 			{
 				raw_tracks_.sample_tracks(sample_time, rounding_policy, track_writer);
@@ -456,6 +486,16 @@ namespace acl
 
 			error_calculation_adapter(const error_calculation_adapter&) = delete;
 			error_calculation_adapter& operator=(const error_calculation_adapter&) = delete;
+
+#ifdef ACL_BIND_POSE
+
+			virtual void initialize_bind_pose(debug_track_writer& track_writer0, debug_track_writer& tracks_writer1) override
+			{
+				(void)track_writer0;
+				tracks_writer1.initialize_bind_pose(raw_tracks_);
+			}
+
+#endif
 
 			virtual void sample_tracks0(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) override
 			{
@@ -562,6 +602,16 @@ namespace acl
 			error_calculation_adapter(const error_calculation_adapter&) = delete;
 			error_calculation_adapter& operator=(const error_calculation_adapter&) = delete;
 
+#ifdef ACL_BIND_POSE
+
+			virtual void initialize_bind_pose(debug_track_writer& track_writer0, debug_track_writer& tracks_writer1) override
+			{
+				(void)track_writer0;
+				tracks_writer1.initialize_bind_pose(raw_tracks_);
+			}
+
+#endif
+
 			virtual void sample_tracks0(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) override
 			{
 				raw_tracks_.sample_tracks(sample_time, rounding_policy, track_writer);
@@ -665,6 +715,17 @@ namespace acl
 			{
 			}
 
+#ifdef ACL_BIND_POSE
+
+			virtual void initialize_bind_pose(debug_track_writer& track_writer0, debug_track_writer& track_writer1) override
+			{
+				(void)track_writer0;
+				(void)track_writer1;
+				ACL_ASSERT(false, "Unreachable code.");
+			}
+
+#endif
+
 			virtual void sample_tracks0(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) override
 			{
 				context0_.seek(sample_time, rounding_policy);
@@ -722,6 +783,17 @@ namespace acl
 			{
 			}
 
+#ifdef ACL_BIND_POSE
+
+			virtual void initialize_bind_pose(debug_track_writer& track_writer0, debug_track_writer& track_writer1) override
+			{
+				(void)track_writer0;
+				(void)track_writer1;
+				ACL_ASSERT(false, "Unreachable code.");
+			}
+
+#endif
+
 			virtual void sample_tracks0(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) override
 			{
 				raw_tracks0_.sample_tracks(sample_time, rounding_policy, track_writer);
@@ -765,6 +837,16 @@ namespace acl
 				, raw_tracks1_(raw_tracks1__)
 			{
 			}
+
+#ifdef ACL_BIND_POSE
+
+			virtual void initialize_bind_pose(debug_track_writer& track_writer0, debug_track_writer& track_writer1) override
+			{
+				(void)track_writer0;
+				(void)track_writer1;
+			}
+
+#endif
 
 			virtual void sample_tracks0(float sample_time, sample_rounding_policy rounding_policy, debug_track_writer& track_writer) override
 			{

--- a/includes/acl/compression/impl/track_stream.h
+++ b/includes/acl/compression/impl/track_stream.h
@@ -37,6 +37,12 @@
 #include <rtm/quatf.h>
 #include <rtm/vector4f.h>
 
+#ifdef ACL_BIND_POSE
+
+#include <rtm/qvvf.h>
+
+#endif
+
 #include <cstdint>
 
 ACL_IMPL_FILE_PRAGMA_PUSH
@@ -317,6 +323,13 @@ namespace acl
 
 		struct transform_streams
 		{
+			
+#ifdef ACL_BIND_POSE
+
+			rtm::qvvf default_value					= rtm::qvv_identity();
+
+#endif
+
 			segment_context* segment				= nullptr;
 			uint32_t bone_index						= k_invalid_track_index;
 			uint32_t parent_bone_index				= k_invalid_track_index;
@@ -333,11 +346,24 @@ namespace acl
 			bool is_scale_constant					= false;
 			bool is_scale_default					= false;
 
+#ifdef ACL_BIND_POSE
+
+			uint8_t padding[2];
+
+#endif
+
 			bool is_stripped_from_output() const { return output_index == k_invalid_track_index; }
 
 			transform_streams duplicate() const
 			{
 				transform_streams copy;
+				
+#ifdef ACL_BIND_POSE
+
+				copy.default_value = default_value;
+
+#endif
+				
 				copy.segment = segment;
 				copy.bone_index = bone_index;
 				copy.parent_bone_index = parent_bone_index;

--- a/includes/acl/compression/impl/write_track_metadata.h
+++ b/includes/acl/compression/impl/write_track_metadata.h
@@ -179,9 +179,25 @@ namespace acl
 						data[2] = desc.constant_rotation_threshold_angle;
 						data[3] = desc.constant_translation_threshold;
 						data[4] = desc.constant_scale_threshold;
+						
+#ifdef ACL_BIND_POSE_BINARY
+
+						rtm::quat_store(desc.default_value.rotation, data + 5);
+						rtm::vector_store(desc.default_value.translation, data + 9);
+						rtm::vector_store(desc.default_value.scale, data + 13);
+					
+					}
+
+					output_buffer += sizeof(float) * 17;					
+					
+#else
+						
 					}
 
 					output_buffer += sizeof(float) * 5;
+					
+#endif
+					
 				}
 			}
 

--- a/includes/acl/core/additive_utils.h
+++ b/includes/acl/core/additive_utils.h
@@ -123,6 +123,15 @@ namespace acl
 	{
 		return additive_format == additive_clip_format8::additive1 ? rtm::vector_zero() : rtm::vector_set(1.0F);
 	}
+	
+#ifdef ACL_BIND_POSE
+
+	inline bool get_default_bind_pose(additive_clip_format8 additive_format)
+	{
+		return (additive_format == additive_clip_format8::none);
+	}
+
+#endif
 
 	inline rtm::qvvf RTM_SIMD_CALL transform_add0(rtm::qvvf_arg0 base, rtm::qvvf_arg1 additive)
 	{

--- a/includes/acl/core/impl/compiler_utils.h
+++ b/includes/acl/core/impl/compiler_utils.h
@@ -92,3 +92,11 @@ namespace acl
 #else
 	#define ACL_SWITCH_CASE_FALLTHROUGH_INTENTIONAL (void)0
 #endif
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Allow users to change the definition of "default transform" from "identity transform" to "bind transform".
+//
+//////////////////////////////////////////////////////////////////////////
+#define ACL_BIND_POSE
+// Punting on this, because it would require a version change.  #define ACL_BIND_POSE_BINARY

--- a/includes/acl/core/impl/compressed_headers.h
+++ b/includes/acl/core/impl/compressed_headers.h
@@ -95,7 +95,18 @@ namespace acl
 			// Bit 3: translation format
 			// Bits [4, 8): rotation format (4 bits)
 			// Bit 8: has database?
+
+#ifdef ACL_BIND_POSE
+
+			// Bit 9: has bind pose?
+			// Bits [10, 31): unused (21 bits)
+
+#else
+
 			// Bits [9, 31): unused (22 bits)
+
+#endif
+
 			// Bit 31: has metadata?
 
 			bool get_has_scale() const { return (misc_packed & 1) != 0; }
@@ -110,6 +121,14 @@ namespace acl
 			void set_rotation_format(rotation_format8 format) { misc_packed = (misc_packed & ~(15 << 4)) | (static_cast<uint32_t>(format) << 4); }
 			bool get_has_database() const { return (misc_packed & (1 << 8)) != 0; }
 			void set_has_database(bool has_database) { misc_packed = (misc_packed & ~(1 << 8)) | (static_cast<uint32_t>(has_database) << 8); }
+
+#ifdef ACL_BIND_POSE
+
+			bool get_default_bind_pose() const { return (misc_packed & (1 << 9)) != 0; }
+			void set_default_bind_pose(bool default_bind_pose) { misc_packed = (misc_packed & ~(1 << 9)) | (static_cast<uint32_t>(default_bind_pose) << 9); }
+
+#endif
+
 			bool get_has_metadata() const { return (misc_packed >> 31) != 0; }
 			void set_has_metadata(bool has_metadata) { misc_packed = (misc_packed & ~(1 << 31)) | (static_cast<uint32_t>(has_metadata) << 31); }
 		};

--- a/includes/acl/core/impl/compressed_tracks.impl.h
+++ b/includes/acl/core/impl/compressed_tracks.impl.h
@@ -173,7 +173,16 @@ namespace acl
 
 		const uint32_t* parent_track_indices = metadata_header.get_parent_track_indices(*this);
 		const uint8_t* descriptions = metadata_header.get_track_descriptions(*this);
+		
+#ifdef ACL_BIND_POSE_BINARY
+
+		const float* description_data = reinterpret_cast<const float*>(descriptions + (track_index * sizeof(float) * 17));		
+			
+#else
+
 		const float* description_data = reinterpret_cast<const float*>(descriptions + (track_index * sizeof(float) * 5));
+
+#endif
 
 		out_description.output_index = track_index;
 		out_description.parent_index = parent_track_indices[track_index];
@@ -182,6 +191,14 @@ namespace acl
 		out_description.constant_rotation_threshold_angle = description_data[2];
 		out_description.constant_translation_threshold = description_data[3];
 		out_description.constant_scale_threshold = description_data[4];
+
+#ifdef ACL_BIND_POSE_BINARY
+
+		out_description.default_value.rotation = rtm::quat_load(description_data + 5);
+		out_description.default_value.translation = rtm::vector_load(description_data + 9);
+		out_description.default_value.scale = rtm::vector_load(description_data + 13);
+
+#endif
 
 		return true;
 	}

--- a/includes/acl/core/impl/debug_track_writer.h
+++ b/includes/acl/core/impl/debug_track_writer.h
@@ -29,6 +29,12 @@
 #include "acl/core/track_types.h"
 #include "acl/core/track_writer.h"
 
+#ifdef ACL_BIND_POSE
+
+#include "acl/compression/track_array.h"
+
+#endif
+
 #include <rtm/scalarf.h>
 #include <rtm/vector4f.h>
 
@@ -58,6 +64,22 @@ namespace acl
 			{
 				allocator.deallocate(tracks_typed.any, buffer_size);
 			}
+			
+#ifdef ACL_BIND_POSE
+
+			static constexpr bool skip_all_defaults() { return true; }
+
+			void initialize_bind_pose(const track_array& tracks)
+			{
+				ACL_ASSERT(type == track_type8::qvvf, "Unexpected track type access");
+				const uint32_t num_tracks_local = num_tracks;
+				for (uint32_t track_index = 0; track_index < num_tracks_local; ++track_index)
+				{
+					tracks_typed.qvvf[track_index] = track_cast<track_qvvf>(tracks[track_index]).get_description().default_value;
+				}
+			}
+
+#endif
 
 			//////////////////////////////////////////////////////////////////////////
 			// Called by the decoder to write out a value for a specified track index.

--- a/includes/acl/core/track_desc.h
+++ b/includes/acl/core/track_desc.h
@@ -28,6 +28,12 @@
 #include "acl/core/track_types.h"
 #include "acl/core/impl/compiler_utils.h"
 
+#ifdef ACL_BIND_POSE
+
+#include <rtm/qvvf.h>
+
+#endif
+
 #include <cstdint>
 
 ACL_IMPL_FILE_PRAGMA_PUSH
@@ -73,6 +79,16 @@ namespace acl
 		//////////////////////////////////////////////////////////////////////////
 		// The track category for this description.
 		static constexpr track_category8 category = track_category8::transformf;
+		
+#ifdef ACL_BIND_POSE
+
+		//////////////////////////////////////////////////////////////////////////
+		// Default tracks are cheaper than static or animated tracks. The game engine 
+		// can apply bind transforms instead of identity transforms if preferred.
+		rtm::qvvf default_value = rtm::qvv_identity();
+		uint32_t padding = 0;
+
+#endif
 
 		//////////////////////////////////////////////////////////////////////////
 		// The track output index. When writing out the compressed data stream, this index

--- a/includes/acl/core/track_writer.h
+++ b/includes/acl/core/track_writer.h
@@ -88,6 +88,24 @@ namespace acl
 		//////////////////////////////////////////////////////////////////////////
 		// Transform track writing
 
+#ifdef ACL_BIND_POSE
+
+		//////////////////////////////////////////////////////////////////////////
+		// This allows the caller of decompress_pose to skip every default channel,
+		// because the caller applies the bind pose before decompression time.
+		// Must be static constexpr!
+		static constexpr bool skip_all_defaults() { return false; }
+
+		//////////////////////////////////////////////////////////////////////////
+		// These allow the caller of decompress_pose to substitute its own bind transforms as defaults
+		// instead of identity transforms.
+		// Must be non-static member functions!
+		bool skip_default_rotation(uint32_t /*track_index*/) { return false; }
+		bool skip_default_translation(uint32_t /*track_index*/) { return false; }
+		bool skip_default_scale(uint32_t /*track_index*/) { return false; }
+
+#endif
+
 		//////////////////////////////////////////////////////////////////////////
 		// These allow the caller of decompress_pose to control which track types they are interested in.
 		// This information allows the codecs to avoid unpacking values that are not needed.

--- a/includes/acl/decompression/impl/transform_track_decompression.h
+++ b/includes/acl/decompression/impl/transform_track_decompression.h
@@ -546,6 +546,82 @@ namespace acl
 			}
 		}
 
+#ifdef ACL_BIND_POSE
+
+		// Force inline this function, we only use it to keep the code readable
+		template<class track_writer_type>
+		RTM_FORCE_INLINE RTM_DISABLE_SECURITY_COOKIE_CHECK void RTM_SIMD_CALL unpack_default_rotation_sub_defaults(
+			const packed_sub_track_types* rotation_sub_track_types, uint32_t last_entry_index, uint32_t padding_mask,
+			rtm::quatf_arg0 default_rotation, track_writer_type& writer)
+		{
+			for (uint32_t entry_index = 0, track_index = 0; entry_index <= last_entry_index; ++entry_index)
+			{
+				uint32_t packed_entry = rotation_sub_track_types[entry_index].types;
+
+				// Mask out everything but default sub-tracks, this way we can early out when we iterate
+				// Each sub-track is either 0 (default), 1 (constant), or 2 (animated)
+				// By flipping the bits with logical NOT, 0 becomes 3, 1 becomes 2, and 2 becomes 1
+				// We then subtract 1 from every group so 3 becomes 2, 2 becomes 1, and 1 becomes 0
+				// Finally, we mask out everything but the second bit for each sub-track
+				// After this, our original default tracks are equal to 2, our constant tracks are equal to 1, and our animated tracks are equal to 0
+				// Testing for default tracks can be done by testing the second bit of each group (same as animated track testing)
+				packed_entry = (~packed_entry - 0x55555555) & 0xAAAAAAAA;
+
+				// Because our last entry might have padding with 0 (default), we have to strip any padding we might have
+				const uint32_t entry_padding_mask = (entry_index == last_entry_index) ? padding_mask : 0xFFFFFFFF;
+				packed_entry &= entry_padding_mask;
+
+				uint32_t curr_entry_track_index = track_index;
+
+				// We might early out below, always skip 16 tracks
+				track_index += 16;
+
+				// Process 4 sub-tracks at a time
+				while (packed_entry != 0)
+				{
+					const uint32_t packed_group = packed_entry;
+					const uint32_t curr_group_track_index = curr_entry_track_index;
+
+					// Move to the next group
+					packed_entry <<= 8;
+					curr_entry_track_index += 4;
+
+					if ((packed_group & 0xAA000000) == 0)
+						continue;	// This group contains no default sub-tracks, skip it
+
+					if ((packed_group & 0x80000000) != 0)
+					{
+						const uint32_t track_index0 = curr_group_track_index + 0;
+						if (!track_writer_type::skip_all_rotations() && !writer.skip_default_rotation(track_index0))
+							writer.write_rotation(track_index0, default_rotation);
+					}
+
+					if ((packed_group & 0x20000000) != 0)
+					{
+						const uint32_t track_index1 = curr_group_track_index + 1;
+						if (!track_writer_type::skip_all_rotations() && !writer.skip_default_rotation(track_index1))
+							writer.write_rotation(track_index1, default_rotation);
+					}
+
+					if ((packed_group & 0x08000000) != 0)
+					{
+						const uint32_t track_index2 = curr_group_track_index + 2;
+						if (!track_writer_type::skip_all_rotations() && !writer.skip_default_rotation(track_index2))
+							writer.write_rotation(track_index2, default_rotation);
+					}
+
+					if ((packed_group & 0x02000000) != 0)
+					{
+						const uint32_t track_index3 = curr_group_track_index + 3;
+						if (!track_writer_type::skip_all_rotations() && !writer.skip_default_rotation(track_index3))
+							writer.write_rotation(track_index3, default_rotation);
+					}
+				}
+			}
+		}
+
+#endif
+
 		// Force inline this function, we only use it to keep the code readable
 		template<class decompression_settings_type, class track_writer_type>
 		RTM_FORCE_INLINE RTM_DISABLE_SECURITY_COOKIE_CHECK void RTM_SIMD_CALL unpack_constant_rotation_sub_tracks(
@@ -779,6 +855,86 @@ namespace acl
 				}
 			}
 		}
+
+#ifdef ACL_BIND_POSE
+
+		// Force inline this function, we only use it to keep the code readable
+		template<class track_writer_type>
+		RTM_FORCE_INLINE RTM_DISABLE_SECURITY_COOKIE_CHECK void RTM_SIMD_CALL unpack_default_translation_sub_defaults(
+			const packed_sub_track_types* translation_sub_track_types, uint32_t last_entry_index, uint32_t padding_mask,
+			rtm::vector4f_arg0 default_translation, track_writer_type& writer)
+		{
+			for (uint32_t entry_index = 0, track_index = 0; entry_index <= last_entry_index; ++entry_index)
+			{
+				uint32_t packed_entry = translation_sub_track_types[entry_index].types;
+
+				// Mask out everything but default sub-tracks, this way we can early out when we iterate
+				// Each sub-track is either 0 (default), 1 (constant), or 2 (animated)
+				// By flipping the bits with logical NOT, 0 becomes 3, 1 becomes 2, and 2 becomes 1
+				// We then subtract 1 from every group so 3 becomes 2, 2 becomes 1, and 1 becomes 0
+				// Finally, we mask out everything but the second bit for each sub-track
+				// After this, our original default tracks are equal to 2, our constant tracks are equal to 1, and our animated tracks are equal to 0
+				// Testing for default tracks can be done by testing the second bit of each group (same as animated track testing)
+				packed_entry = (~packed_entry - 0x55555555) & 0xAAAAAAAA;
+
+				// Because our last entry might have padding with 0 (default), we have to strip any padding we might have
+				const uint32_t entry_padding_mask = (entry_index == last_entry_index) ? padding_mask : 0xFFFFFFFF;
+				packed_entry &= entry_padding_mask;
+
+				uint32_t curr_entry_track_index = track_index;
+
+				// We might early out below, always skip 16 tracks
+				track_index += 16;
+
+				// Process 4 sub-tracks at a time
+				while (packed_entry != 0)
+				{
+					const uint32_t packed_group = packed_entry;
+					const uint32_t curr_group_track_index = curr_entry_track_index;
+
+					// Move to the next group
+					packed_entry <<= 8;
+					curr_entry_track_index += 4;
+
+					if ((packed_group & 0xAA000000) == 0)
+						continue;	// This group contains no default sub-tracks, skip it
+
+					if ((packed_group & 0x80000000) != 0)
+					{
+						const uint32_t track_index0 = curr_group_track_index + 0;
+
+						if (!track_writer_type::skip_all_translations() && !writer.skip_default_translation(track_index0))
+							writer.write_translation(track_index0, default_translation);
+					}
+
+					if ((packed_group & 0x20000000) != 0)
+					{
+						const uint32_t track_index1 = curr_group_track_index + 1;
+
+						if (!track_writer_type::skip_all_translations() && !writer.skip_default_translation(track_index1))
+							writer.write_translation(track_index1, default_translation);
+					}
+
+					if ((packed_group & 0x08000000) != 0)
+					{
+						const uint32_t track_index2 = curr_group_track_index + 2;
+
+						if (!track_writer_type::skip_all_translations() && !writer.skip_default_translation(track_index2))
+							writer.write_translation(track_index2, default_translation);
+					}
+
+					if ((packed_group & 0x02000000) != 0)
+					{
+						const uint32_t track_index3 = curr_group_track_index + 3;
+
+						if (!track_writer_type::skip_all_translations() && !writer.skip_default_translation(track_index3))
+							writer.write_translation(track_index3, default_translation);
+					}
+				}
+			}
+		}
+
+#endif
 
 		// Force inline this function, we only use it to keep the code readable
 		template<class track_writer_type>
@@ -1026,6 +1182,86 @@ namespace acl
 			}
 		}
 
+#ifdef ACL_BIND_POSE
+
+		// Force inline this function, we only use it to keep the code readable
+		template<class track_writer_type>
+		RTM_FORCE_INLINE RTM_DISABLE_SECURITY_COOKIE_CHECK void RTM_SIMD_CALL unpack_default_scale_sub_defaults(
+			const packed_sub_track_types* scale_sub_track_types, uint32_t last_entry_index, uint32_t padding_mask,
+			rtm::vector4f_arg0 default_scale, track_writer_type& writer)
+		{
+			for (uint32_t entry_index = 0, track_index = 0; entry_index <= last_entry_index; ++entry_index)
+			{
+				uint32_t packed_entry = scale_sub_track_types[entry_index].types;
+
+				// Mask out everything but default sub-tracks, this way we can early out when we iterate
+				// Each sub-track is either 0 (default), 1 (constant), or 2 (animated)
+				// By flipping the bits with logical NOT, 0 becomes 3, 1 becomes 2, and 2 becomes 1
+				// We then subtract 1 from every group so 3 becomes 2, 2 becomes 1, and 1 becomes 0
+				// Finally, we mask out everything but the second bit for each sub-track
+				// After this, our original default tracks are equal to 2, our constant tracks are equal to 1, and our animated tracks are equal to 0
+				// Testing for default tracks can be done by testing the second bit of each group (same as animated track testing)
+				packed_entry = (~packed_entry - 0x55555555) & 0xAAAAAAAA;
+
+				// Because our last entry might have padding with 0 (default), we have to strip any padding we might have
+				const uint32_t entry_padding_mask = (entry_index == last_entry_index) ? padding_mask : 0xFFFFFFFF;
+				packed_entry &= entry_padding_mask;
+
+				uint32_t curr_entry_track_index = track_index;
+
+				// We might early out below, always skip 16 tracks
+				track_index += 16;
+
+				// Process 4 sub-tracks at a time
+				while (packed_entry != 0)
+				{
+					const uint32_t packed_group = packed_entry;
+					const uint32_t curr_group_track_index = curr_entry_track_index;
+
+					// Move to the next group
+					packed_entry <<= 8;
+					curr_entry_track_index += 4;
+
+					if ((packed_group & 0xAA000000) == 0)
+						continue;	// This group contains no default sub-tracks, skip it
+
+					if ((packed_group & 0x80000000) != 0)
+					{
+						const uint32_t track_index0 = curr_group_track_index + 0;
+
+						if (!track_writer_type::skip_all_scales() && !writer.skip_default_scale(track_index0))
+							writer.write_scale(track_index0, default_scale);
+					}
+
+					if ((packed_group & 0x20000000) != 0)
+					{
+						const uint32_t track_index1 = curr_group_track_index + 1;
+
+						if (!track_writer_type::skip_all_scales() && !writer.skip_default_scale(track_index1))
+							writer.write_scale(track_index1, default_scale);
+					}
+
+					if ((packed_group & 0x08000000) != 0)
+					{
+						const uint32_t track_index2 = curr_group_track_index + 2;
+
+						if (!track_writer_type::skip_all_scales() && !writer.skip_default_scale(track_index2))
+							writer.write_scale(track_index2, default_scale);
+					}
+
+					if ((packed_group & 0x02000000) != 0)
+					{
+						const uint32_t track_index3 = curr_group_track_index + 3;
+
+						if (!track_writer_type::skip_all_scales() && !writer.skip_default_scale(track_index3))
+							writer.write_scale(track_index3, default_scale);
+					}
+				}
+			}
+		}
+
+#endif
+
 		// Force inline this function, we only use it to keep the code readable
 		template<class track_writer_type>
 		RTM_FORCE_INLINE RTM_DISABLE_SECURITY_COOKIE_CHECK void RTM_SIMD_CALL unpack_constant_scale_sub_tracks(
@@ -1222,6 +1458,13 @@ namespace acl
 			const rtm::vector4f default_scale = rtm::vector_set(float(header.get_default_scale()));
 			const uint32_t has_scale = context.has_scale;
 
+#ifdef ACL_BIND_POSE
+
+			const bool has_bind_pose = header.get_default_bind_pose();
+			const bool skip_bind_pose = track_writer_type::skip_all_defaults() && has_bind_pose;
+
+#endif
+
 			const packed_sub_track_types* sub_track_types = get_transform_tracks_header(*context.tracks).get_sub_track_types();
 			const uint32_t num_sub_track_entries = (num_tracks + k_num_sub_tracks_per_packed_entry - 1) / k_num_sub_tracks_per_packed_entry;
 			const uint32_t num_padded_sub_tracks = (num_sub_track_entries * k_num_sub_tracks_per_packed_entry) - num_tracks;
@@ -1278,7 +1521,26 @@ namespace acl
 
 			// Unpack our default rotation sub-tracks
 			// Default rotation sub-tracks are uncommon, this shouldn't take much more than 50 cycles
+
+#ifdef ACL_BIND_POSE
+
+			if (!skip_bind_pose)
+			{
+				if (has_bind_pose)
+				{
+					unpack_default_rotation_sub_defaults(rotation_sub_track_types, last_entry_index, padding_mask, default_rotation, writer);
+				}
+				else
+				{
+					unpack_default_rotation_sub_tracks(rotation_sub_track_types, last_entry_index, padding_mask, default_rotation, writer);
+				}
+			}
+
+#else
+
 			unpack_default_rotation_sub_tracks(rotation_sub_track_types, last_entry_index, padding_mask, default_rotation, writer);
+
+#endif
 
 			// Unpack our constant rotation sub-tracks
 			// Constant rotation sub-tracks are very common, this should take at least 200 cycles
@@ -1308,11 +1570,84 @@ namespace acl
 
 			// Unpack our default translation sub-tracks
 			// Default translation sub-tracks are rare, this shouldn't take much more than 50 cycles
+
+#ifdef ACL_BIND_POSE
+
+			if (!skip_bind_pose)
+			{
+				if (has_bind_pose)
+				{
+					unpack_default_translation_sub_defaults(translation_sub_track_types, last_entry_index, padding_mask, default_translation, writer);
+				}
+				else
+				{
+					unpack_default_translation_sub_tracks(translation_sub_track_types, last_entry_index, padding_mask, default_translation, writer);
+				}
+			}
+
+#else
+
 			unpack_default_translation_sub_tracks(translation_sub_track_types, last_entry_index, padding_mask, default_translation, writer);
+
+#endif
 
 			// Unpack our constant translation sub-tracks
 			// Constant translation sub-tracks are very common, this should take at least 200 cycles
 			unpack_constant_translation_sub_tracks(translation_sub_track_types, last_entry_index, constant_track_cache, writer);
+
+#ifdef ACL_BIND_POSE
+
+			if (!skip_bind_pose)
+			{
+				if (has_bind_pose)
+				{
+					if (has_scale)
+					{
+						// Unpack our default scale sub-tracks
+						// Scale sub-tracks are almost always default, this should take at least 200 cycles
+						unpack_default_scale_sub_defaults(scale_sub_track_types, last_entry_index, padding_mask, default_scale, writer);
+
+						// Unpack our constant scale sub-tracks
+						// Constant scale sub-tracks are very rare, this shouldn't take much more than 50 cycles
+						unpack_constant_scale_sub_tracks(scale_sub_track_types, last_entry_index, constant_track_cache, writer);
+					}
+					else
+					{
+						// No scale present, everything is just the default value
+						// This shouldn't take much more than 50 cycles
+						for (uint32_t track_index = 0; track_index < num_tracks; ++track_index)
+						{
+							if (!track_writer_type::skip_all_scales() && !writer.skip_default_scale(track_index))
+								writer.write_scale(track_index, default_scale);
+						}
+					}
+				}
+				else
+				{
+					if (has_scale)
+					{
+						// Unpack our default scale sub-tracks
+						// Scale sub-tracks are almost always default, this should take at least 200 cycles
+						unpack_default_scale_sub_tracks(scale_sub_track_types, last_entry_index, padding_mask, default_scale, writer);
+
+						// Unpack our constant scale sub-tracks
+						// Constant scale sub-tracks are very rare, this shouldn't take much more than 50 cycles
+						unpack_constant_scale_sub_tracks(scale_sub_track_types, last_entry_index, constant_track_cache, writer);
+					}
+					else
+					{
+						// No scale present, everything is just the default value
+						// This shouldn't take much more than 50 cycles
+						for (uint32_t track_index = 0; track_index < num_tracks; ++track_index)
+						{
+							if (!track_writer_type::skip_all_scales() && !writer.skip_track_scale(track_index))
+								writer.write_scale(track_index, default_scale);
+						}
+					}
+				}
+			}
+
+#else
 
 			if (has_scale)
 			{
@@ -1334,6 +1669,8 @@ namespace acl
 						writer.write_scale(track_index, default_scale);
 				}
 			}
+
+#endif
 
 			{
 				// By now the first few cache lines of our segment data has landed in the L2
@@ -1436,6 +1773,13 @@ namespace acl
 			const rtm::vector4f default_scale = rtm::vector_set(float(tracks_header_.get_default_scale()));
 			const uint32_t has_scale = context.has_scale;
 
+#ifdef ACL_BIND_POSE
+
+			const bool has_bind_pose = tracks_header_.get_default_bind_pose();
+			const bool skip_bind_pose = track_writer_type::skip_all_defaults() && has_bind_pose;
+
+#endif
+
 			const packed_sub_track_types* sub_track_types = get_transform_tracks_header(*context.tracks).get_sub_track_types();
 			const uint32_t num_sub_track_entries = (num_tracks + k_num_sub_tracks_per_packed_entry - 1) / k_num_sub_tracks_per_packed_entry;
 
@@ -1465,6 +1809,32 @@ namespace acl
 
 			if (combined_sub_track_type == 0)
 			{
+
+#ifdef ACL_BIND_POSE
+
+				if (skip_bind_pose)
+				{
+					return;
+				}
+				else if (has_bind_pose)
+				{
+					if (!writer.skip_default_rotation(track_index))
+					{
+						writer.write_rotation(track_index, default_rotation);
+					}
+					if (!writer.skip_default_translation(track_index))
+					{
+						writer.write_translation(track_index, default_translation);
+					}
+					if (!writer.skip_default_scale(track_index))
+					{
+						writer.write_scale(track_index, default_scale);
+					}
+					return;
+				}
+
+#endif
+
 				// Everything is default
 				writer.write_rotation(track_index, default_rotation);
 				writer.write_translation(track_index, default_translation);
@@ -1590,6 +1960,12 @@ namespace acl
 
 			// Finally reached our desired track, unpack it
 
+#ifdef ACL_BIND_POSE
+
+			if (!(has_bind_pose && (rotation_sub_track_type == 0) && (skip_bind_pose || writer.skip_default_rotation(track_index))))
+
+#endif
+
 			{
 				rtm::quatf rotation;
 				if (rotation_sub_track_type == 0)
@@ -1601,6 +1977,12 @@ namespace acl
 
 				writer.write_rotation(track_index, rotation);
 			}
+
+#ifdef ACL_BIND_POSE
+
+			if (!(has_bind_pose && (translation_sub_track_type == 0) && (skip_bind_pose || writer.skip_default_translation(track_index))))
+
+#endif
 
 			{
 				rtm::vector4f translation;
@@ -1614,6 +1996,11 @@ namespace acl
 				writer.write_translation(track_index, translation);
 			}
 
+#ifdef ACL_BIND_POSE
+
+			if (!(has_bind_pose && (scale_sub_track_type == 0) && (skip_bind_pose || writer.skip_default_scale(track_index))))
+
+#endif
 			{
 				rtm::vector4f scale;
 				if (scale_sub_track_type == 0)

--- a/includes/acl/io/clip_reader.h
+++ b/includes/acl/io/clip_reader.h
@@ -605,6 +605,12 @@ namespace acl
 
 					rtm::qvvf bind_transform_ = rtm::qvv_cast(bind_transform);
 					bind_transform_.rotation = rtm::quat_normalize(bind_transform_.rotation);
+					
+#ifdef ACL_BIND_POSE
+
+					(*tracks)[i].get_description().default_value = bind_transform_;
+
+#endif
 
 					(*bind_pose)[i] = bind_transform_;
 				}
@@ -859,6 +865,12 @@ namespace acl
 					if (m_parser.try_read("bind_scale", scale, 3, 0.0) && !counting)
 						bind_transform.scale = rtm::vector_cast(rtm::vector_load3(&scale[0]));
 				}
+
+#ifdef ACL_BIND_POSE
+
+				transform_desc.default_value = bind_transform;
+
+#endif
 
 				if (bind_pose != nullptr)
 					(*bind_pose)[i] = bind_transform;

--- a/make.py
+++ b/make.py
@@ -15,7 +15,7 @@ import time
 import zipfile
 
 # The current test/decompression data version in use
-current_test_data = 'test_data_v5'
+current_test_data = 'test_data_v4' # ACL_BIND_POSE test_data_v5
 current_decomp_data = 'decomp_data_v7'
 
 def parse_argv():
@@ -516,7 +516,7 @@ def do_prepare_regression_test_data(test_data_dir, args):
 	regression_clips = []
 	for (dirpath, dirnames, filenames) in os.walk(current_test_data_dir):
 		for filename in filenames:
-			if not filename.endswith('.acl'):
+			if not filename.endswith('.acl.sjson'): # ACL_BIND_POSE .acl
 				continue
 
 			clip_filename = os.path.join(dirpath, filename)
@@ -589,7 +589,7 @@ def do_prepare_decompression_test_data(test_data_dir, args):
 	clips = []
 	for (dirpath, dirnames, filenames) in os.walk(current_data_dir):
 		for filename in filenames:
-			if not filename.endswith('.acl'):
+			if not filename.endswith('.acl.sjson'): # ACL_BIND_POSE .acl
 				continue
 
 			clip_filename = os.path.join(dirpath, filename)
@@ -666,7 +666,7 @@ def do_regression_tests_cmake(test_data_dir, args):
 	current_test_data_dir = os.path.join(test_data_dir, current_test_data)
 	for (dirpath, dirnames, filenames) in os.walk(current_test_data_dir):
 		for filename in filenames:
-			if not filename.endswith('.acl'):
+			if not filename.endswith('.acl.sjson'): # ACL_BIND_POSE .acl
 				continue
 
 			clip_filename = os.path.join(dirpath, filename)

--- a/tools/acl_compressor/sources/validate_tracks.cpp
+++ b/tools/acl_compressor/sources/validate_tracks.cpp
@@ -74,6 +74,12 @@ void validate_accuracy(iallocator& allocator, const track_array_qvvf& raw_tracks
 
 	debug_track_writer track_writer(allocator, track_type8::qvvf, num_bones);
 
+#ifdef ACL_BIND_POSE
+
+	track_writer.initialize_bind_pose(raw_tracks);
+
+#endif
+
 	{
 		// Try to decompress something at 0.0, if we have no tracks or samples, it should be handled
 		context.seek(0.0F, sample_rounding_policy::nearest);
@@ -135,6 +141,16 @@ void validate_accuracy(iallocator& allocator, const track_array& raw_tracks, con
 	debug_track_writer raw_track_writer(allocator, track_type, num_tracks);
 	debug_track_writer lossy_tracks_writer(allocator, track_type, num_tracks);
 	debug_track_writer lossy_track_writer(allocator, track_type, num_tracks);
+
+#ifdef ACL_BIND_POSE
+
+	if (track_type == track_type8::qvvf)
+	{
+		lossy_tracks_writer.initialize_bind_pose(raw_tracks);
+		lossy_track_writer.initialize_bind_pose(raw_tracks);
+	}
+
+#endif
 
 	const rtm::vector4f zero = rtm::vector_zero();
 
@@ -342,6 +358,15 @@ void validate_metadata(const track_array& raw_tracks, const compressed_tracks& t
 			ACL_ASSERT(raw_desc.constant_rotation_threshold_angle == compressed_desc.constant_rotation_threshold_angle, "Unexpected constant_rotation_threshold_angle");
 			ACL_ASSERT(raw_desc.constant_translation_threshold == compressed_desc.constant_translation_threshold, "Unexpected constant_translation_threshold");
 			ACL_ASSERT(raw_desc.constant_scale_threshold == compressed_desc.constant_scale_threshold, "Unexpected constant_scale_threshold");
+			
+#ifdef ACL_BIND_POSE_BINARY
+
+			ACL_ASSERT(rtm::quat_near_equal(raw_desc.default_value.rotation, compressed_desc.default_value.rotation, 0.0F), "Unexpected default_value.rotation");
+			ACL_ASSERT(rtm::vector_all_near_equal(raw_desc.default_value.translation, compressed_desc.default_value.translation, 0.0F), "Unexpected default_value.translation");
+			ACL_ASSERT(rtm::vector_all_near_equal(raw_desc.default_value.scale, compressed_desc.default_value.scale, 0.0F), "Unexpected default_value.scale");
+
+#endif
+			
 		}
 	}
 	else
@@ -414,6 +439,15 @@ static void compare_raw_with_compressed(iallocator& allocator, const track_array
 			ACL_ASSERT(raw_desc.constant_rotation_threshold_angle == desc.constant_rotation_threshold_angle, "Unexpected constant_rotation_threshold_angle");
 			ACL_ASSERT(raw_desc.constant_translation_threshold == desc.constant_translation_threshold, "Unexpected constant_translation_threshold");
 			ACL_ASSERT(raw_desc.constant_scale_threshold == desc.constant_scale_threshold, "Unexpected constant_scale_threshold");
+
+#ifdef ACL_BIND_POSE_BINARY
+
+			ACL_ASSERT(rtm::quat_near_equal(raw_desc.default_value.rotation, desc.default_value.rotation, 0.0F), "Unexpected default_value.rotation");
+			ACL_ASSERT(rtm::vector_all_near_equal(raw_desc.default_value.translation, desc.default_value.translation, 0.0F), "Unexpected default_value.translation");
+			ACL_ASSERT(rtm::vector_all_near_equal(raw_desc.default_value.scale, desc.default_value.scale, 0.0F), "Unexpected default_value.scale");
+
+#endif
+
 		}
 	}
 
@@ -425,6 +459,15 @@ static void compare_raw_with_compressed(iallocator& allocator, const track_array
 
 	const track_type8 track_type = raw_tracks.get_track_type();
 	acl_impl::debug_track_writer writer(allocator, track_type, num_tracks);
+
+#ifdef ACL_BIND_POSE
+
+	if(track_category == track_category8::transformf)
+	{
+		writer.initialize_bind_pose(raw_tracks);
+	}
+
+#endif
 
 	const uint32_t num_samples = raw_tracks.get_num_samples_per_track();
 	const float sample_rate = raw_tracks.get_sample_rate();

--- a/tools/acl_decompressor/sources/benchmark.cpp
+++ b/tools/acl_decompressor/sources/benchmark.cpp
@@ -226,6 +226,15 @@ static void benchmark_decompression(benchmark::State& state)
 	const uint32_t num_tracks = compressed_tracks.get_num_tracks();
 	acl::acl_impl::debug_track_writer pose_writer(s_allocator, acl::track_type8::qvvf, num_tracks);
 
+#ifdef ACL_BIND_POSE
+
+	if((decompression_function == DecompressionFunction::DecompressPose) || (decompression_function == DecompressionFunction::DecompressBone))
+	{
+		pose_writer.initialize_bind_pose(raw_tracks);
+	}
+
+#endif
+
 	// Flush the CPU cache
 	memset_impl(flush_buffer + k_vmem_padding, k_flush_buffer_size, 1);
 


### PR DESCRIPTION
ACL_BIND_POSE allows users to change the definition of "default transform" from "identity transform" to "bind transform".

Punting on ACL_BIND_POSE_BINARY, because it would require a version change.  In the meantime, binary ACL metadata applies identity transforms, which works fine for pre-existing files, but will break regression tests for new files that prefer bind transforms.