### PR TITLE
fix: improved precision of constant and default tracks

### DIFF
--- a/includes/acl/compression/impl/track_stream.h
+++ b/includes/acl/compression/impl/track_stream.h
@@ -279,19 +279,26 @@ namespace acl
 		class track_stream_range
 		{
 		public:
-			static track_stream_range RTM_SIMD_CALL from_min_max(rtm::vector4f_arg0 min, rtm::vector4f_arg1 max)
+			static track_stream_range RTM_SIMD_CALL from_min_max(rtm::vector4f_arg0 min, rtm::vector4f_arg1 max IF_ACL_BIND_POSE(, rtm::vector4f_arg2 weighted_average))
 			{
-				return track_stream_range(min, rtm::vector_sub(max, min));
+				return track_stream_range(min, rtm::vector_sub(max, min) IF_ACL_BIND_POSE(, weighted_average));
 			}
 
-			static track_stream_range RTM_SIMD_CALL from_min_extent(rtm::vector4f_arg0 min, rtm::vector4f_arg1 extent)
+			static track_stream_range RTM_SIMD_CALL from_min_extent(rtm::vector4f_arg0 min, rtm::vector4f_arg1 extent IF_ACL_BIND_POSE(, rtm::vector4f_arg2 weighted_average))
 			{
-				return track_stream_range(min, extent);
+				return track_stream_range(min, extent IF_ACL_BIND_POSE(, weighted_average));
 			}
 
 			track_stream_range()
 				: m_min(rtm::vector_zero())
 				, m_extent(rtm::vector_zero())
+
+#ifdef ACL_BIND_POSE
+
+				, m_weighted_average(rtm::vector_zero())
+
+#endif
+
 			{}
 
 			rtm::vector4f RTM_SIMD_CALL get_min() const { return m_min; }
@@ -302,14 +309,34 @@ namespace acl
 
 			bool is_constant(float threshold) const { return rtm::vector_all_less_than(rtm::vector_abs(m_extent), rtm::vector_set(threshold)); }
 
+#ifdef ACL_BIND_POSE
+
+			rtm::vector4f RTM_SIMD_CALL get_weighted_average() const { return m_weighted_average; }
+
+#endif
+
 		private:
-			track_stream_range(rtm::vector4f_arg0 min, rtm::vector4f_arg1 extent)
+			track_stream_range(rtm::vector4f_arg0 min, rtm::vector4f_arg1 extent IF_ACL_BIND_POSE(, rtm::vector4f_arg2 weighted_average))
 				: m_min(min)
 				, m_extent(extent)
+
+#ifdef ACL_BIND_POSE
+
+				, m_weighted_average(weighted_average)
+
+#endif
+
 			{}
 
 			rtm::vector4f	m_min;
 			rtm::vector4f	m_extent;
+
+#ifdef ACL_BIND_POSE
+
+			rtm::vector4f	m_weighted_average;
+
+#endif
+
 		};
 
 		struct transform_range

--- a/includes/acl/core/impl/compiler_utils.h
+++ b/includes/acl/core/impl/compiler_utils.h
@@ -100,3 +100,8 @@ namespace acl
 //////////////////////////////////////////////////////////////////////////
 #define ACL_BIND_POSE
 // Punting on this, because it would require a version change.  #define ACL_BIND_POSE_BINARY
+#ifdef ACL_BIND_POSE
+#define IF_ACL_BIND_POSE(...) __VA_ARGS__
+#else
+#define IF_ACL_BIND_POSE(...)
+#endif


### PR DESCRIPTION
I noticed constant and default precision issues while working on _fix/improve-quantization-error_, and the fixes were in the vicinity of my ACL_BIND_POSE changes, so I put them in this branch.  Feel free to link this pull request to https://github.com/nfrechette/acl/issues/359

In addition to quality, it buys me a modest 0.2% size improvement over the previous ACL_BIND_POSE(which is a much bigger size improvement over standard ACL).  YMMV.