### PR TITLE
fix: improved precision of constant tracks within segments

### DIFF
--- a/includes/acl/compression/impl/quantize_streams.h
+++ b/includes/acl/compression/impl/quantize_streams.h
@@ -347,10 +347,19 @@ namespace acl
 
 			if (is_constant_bit_rate(bit_rate))
 			{
+
+#ifdef ACL_BIND_POSE
+
+				const rtm::vector4f normalized_rotation = clip_range.get_weighted_average();
+
+#else
+
 				rtm::vector4f rotation = raw_clip_stream.get_raw_sample<rtm::vector4f>(context.segment_sample_start_index);
 				rotation = convert_rotation(rotation, rotation_format8::quatf_full, rotation_format8::quatf_drop_w_variable);
 
 				const rtm::vector4f normalized_rotation = normalize_sample(rotation, clip_range);
+
+#endif
 
 				uint8_t* quantized_ptr = quantized_stream.get_raw_sample_ptr(0);
 				pack_vector3_u48_unsafe(normalized_rotation, quantized_ptr);
@@ -392,7 +401,16 @@ namespace acl
 
 			const transform_streams& raw_bone_stream = context.raw_bone_streams[bone_index];
 			const rotation_format8 highest_bit_rate = get_highest_variant_precision(rotation_variant8::quat_drop_w);
+
+#ifdef ACL_BIND_POSE
+
+			const track_stream_range& bone_range = context.segment->ranges[bone_index].rotation;
+
+#else
+
 			const track_stream_range& bone_range = context.clip.ranges[bone_index].rotation;
+
+#endif
 
 			// If our format is variable, we keep them fixed at the highest bit rate in the variant
 			if (bone_stream.is_rotation_constant)
@@ -461,8 +479,16 @@ namespace acl
 
 			if (is_constant_bit_rate(bit_rate))
 			{
+
+#ifdef ACL_BIND_POSE
+
+				const rtm::vector4f normalized_translation = clip_range.get_weighted_average();
+
+#else
 				const rtm::vector4f translation = raw_clip_stream.get_raw_sample<rtm::vector4f>(context.segment_sample_start_index);
 				const rtm::vector4f normalized_translation = normalize_sample(translation, clip_range);
+
+#endif
 
 				uint8_t* quantized_ptr = quantized_stream.get_raw_sample_ptr(0);
 				pack_vector3_u48_unsafe(normalized_translation, quantized_ptr);
@@ -501,7 +527,16 @@ namespace acl
 			if (bone_stream.is_translation_default)
 				return;
 
+#ifdef ACL_BIND_POSE
+
+			const track_stream_range& bone_range = context.segment->ranges[bone_index].translation;
+
+#else
+
 			const track_stream_range& bone_range = context.clip.ranges[bone_index].translation;
+
+#endif
+
 			const transform_streams& raw_bone_stream = context.raw_bone_streams[bone_index];
 
 			// Constant translation tracks store the remaining sample with full precision
@@ -571,8 +606,17 @@ namespace acl
 
 			if (is_constant_bit_rate(bit_rate))
 			{
+
+#ifdef ACL_BIND_POSE
+
+				const rtm::vector4f normalized_scale = clip_range.get_weighted_average();
+
+#else
+
 				const rtm::vector4f scale = raw_clip_stream.get_raw_sample<rtm::vector4f>(context.segment_sample_start_index);
 				const rtm::vector4f normalized_scale = normalize_sample(scale, clip_range);
+
+#endif
 
 				uint8_t* quantized_ptr = quantized_stream.get_raw_sample_ptr(0);
 				pack_vector3_u48_unsafe(normalized_scale, quantized_ptr);
@@ -611,7 +655,16 @@ namespace acl
 			if (bone_stream.is_scale_default)
 				return;
 
+#ifdef ACL_BIND_POSE
+
+			const track_stream_range& bone_range = context.segment->ranges[bone_index].scale;
+
+#else
+
 			const track_stream_range& bone_range = context.clip.ranges[bone_index].scale;
+
+#endif
+
 			const transform_streams& raw_bone_stream = context.raw_bone_streams[bone_index];
 
 			// Constant scale tracks store the remaining sample with full precision


### PR DESCRIPTION
Similar to my previous pull request, for constant tracks within segments this time.