### PR TITLE
fix: improved quantization range

### DIFF
--- a/includes/acl/core/impl/compiler_utils.h
+++ b/includes/acl/core/impl/compiler_utils.h
@@ -92,3 +92,22 @@ namespace acl
 #else
 	#define ACL_SWITCH_CASE_FALLTHROUGH_INTENTIONAL (void)0
 #endif
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Stock ACL fails strict unit tests.
+//
+//////////////////////////////////////////////////////////////////////////
+#define ACL_UNIT_TEST_STRICT
+
+//////////////////////////////////////////////////////////////////////////
+//
+//
+// ACL_UNIT_TEST_STRICT fails without ACL_PACKING_PRECISION_BOOST, because quantizing over [0.0F, 1.0F] is less accurate
+// than [-0.5F, 0.5F].  
+//
+// Always floor after scaling, and before shifting from -halfQ..halfQ to 0..fullQ.  Otherwise, IEEE float addition will
+// round the result before you get a chance to floor it.
+//
+//////////////////////////////////////////////////////////////////////////
+#define ACL_PACKING_PRECISION_BOOST

--- a/includes/acl/math/quat_packing.h
+++ b/includes/acl/math/quat_packing.h
@@ -52,6 +52,8 @@ namespace acl
 		return rtm::vector_to_quat(unpack_vector4_128(data_ptr));
 	}
 
+#ifndef ACL_PACKING_PRECISION_BOOST
+
 	inline void RTM_SIMD_CALL pack_quat_96(rtm::quatf_arg0 rotation, uint8_t* out_rotation_data)
 	{
 		rtm::vector4f rotation_xyz = rtm::quat_to_vector(rtm::quat_ensure_positive_w(rotation));
@@ -88,6 +90,8 @@ namespace acl
 		rtm::vector4f rotation_xyz = unpack_vector3_32(11, 11, 10, false, data_ptr);
 		return rtm::quat_from_positive_w(rotation_xyz);
 	}
+
+#endif
 
 	//////////////////////////////////////////////////////////////////////////
 

--- a/make.py
+++ b/make.py
@@ -15,7 +15,7 @@ import time
 import zipfile
 
 # The current test/decompression data version in use
-current_test_data = 'test_data_v5'
+current_test_data = 'test_data_v4' # ACL_PACKING_PRECISION_BOOST test_data_v5
 current_decomp_data = 'decomp_data_v7'
 
 def parse_argv():
@@ -516,7 +516,7 @@ def do_prepare_regression_test_data(test_data_dir, args):
 	regression_clips = []
 	for (dirpath, dirnames, filenames) in os.walk(current_test_data_dir):
 		for filename in filenames:
-			if not filename.endswith('.acl'):
+			if not filename.endswith('.acl.sjson'): # ACL_PACKING_PRECISION_BOOST .acl
 				continue
 
 			clip_filename = os.path.join(dirpath, filename)
@@ -589,7 +589,7 @@ def do_prepare_decompression_test_data(test_data_dir, args):
 	clips = []
 	for (dirpath, dirnames, filenames) in os.walk(current_data_dir):
 		for filename in filenames:
-			if not filename.endswith('.acl'):
+			if not filename.endswith('.acl.sjson'): # ACL_PACKING_PRECISION_BOOST .acl
 				continue
 
 			clip_filename = os.path.join(dirpath, filename)
@@ -666,7 +666,7 @@ def do_regression_tests_cmake(test_data_dir, args):
 	current_test_data_dir = os.path.join(test_data_dir, current_test_data)
 	for (dirpath, dirnames, filenames) in os.walk(current_test_data_dir):
 		for filename in filenames:
-			if not filename.endswith('.acl'):
+			if not filename.endswith('.acl.sjson'): # ACL_PACKING_PRECISION_BOOST .acl
 				continue
 
 			clip_filename = os.path.join(dirpath, filename)

--- a/tests/sources/math/test_quat_packing.cpp
+++ b/tests/sources/math/test_quat_packing.cpp
@@ -51,6 +51,8 @@ TEST_CASE("quat packing math", "[math][quat][packing]")
 		CHECK((float)quat_get_w(quat0) == (float)quat_get_w(quat1));
 	}
 
+#ifndef ACL_PACKING_PRECISION_BOOST
+
 	{
 		UnalignedBuffer tmp0;
 		pack_quat_96(quat0, &tmp0.buffer[0]);
@@ -80,6 +82,8 @@ TEST_CASE("quat packing math", "[math][quat][packing]")
 		CHECK(scalar_near_equal((float)quat_get_z(quat0), (float)quat_get_z(quat1), 1.0E-3F));
 		CHECK(scalar_near_equal((float)quat_get_w(quat0), (float)quat_get_w(quat1), 1.0E-3F));
 	}
+
+#endif
 
 	CHECK(get_packed_rotation_size(rotation_format8::quatf_full) == 16);
 	CHECK(get_packed_rotation_size(rotation_format8::quatf_drop_w_full) == 12);

--- a/tests/sources/math/test_scalar_packing.cpp
+++ b/tests/sources/math/test_scalar_packing.cpp
@@ -41,41 +41,127 @@ static_assert((offsetof(UnalignedBuffer, buffer) % 2) == 0, "Minimum packing ali
 
 TEST_CASE("scalar packing math", "[math][scalar][packing]")
 {
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+	for (uint8_t num_bits = 1; num_bits <= 23; ++num_bits)
+	{
+		INFO("num_bits: " << int(num_bits));
+
+#else
+
 	const float threshold = 1.0E-6F;
 
 	const uint8_t max_num_bits = 23;
 	for (uint8_t num_bits = 1; num_bits < max_num_bits; ++num_bits)
 	{
+
+#endif
+
 		const uint32_t max_value = (1 << num_bits) - 1;
 
 		CHECK(pack_scalar_unsigned(0.0F, num_bits) == 0);
 		CHECK(pack_scalar_unsigned(1.0F, num_bits) == max_value);
 		CHECK(unpack_scalar_unsigned(0, num_bits) == 0.0F);
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+		CHECK(unpack_scalar_unsigned(max_value, num_bits) == 1.0F);
+
+#else
+
 		CHECK(rtm::scalar_near_equal(unpack_scalar_unsigned(max_value, num_bits), 1.0F, threshold));
+
+#endif
+
+#if !defined(ACL_PACKING_PRECISION_BOOST) && !defined(ACL_UNIT_TEST_STRICT)
 
 		CHECK(pack_scalar_signed(-1.0F, num_bits) == 0);
 		CHECK(pack_scalar_signed(1.0F, num_bits) == max_value);
 		CHECK(unpack_scalar_signed(0, num_bits) == -1.0F);
 		CHECK(rtm::scalar_near_equal(unpack_scalar_signed(max_value, num_bits), 1.0F, threshold));
 
+#endif
+
 		uint32_t num_errors = 0;
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+		const float max_error = 1.0F - std::nextafter((rtm::scalar_safe_to_float(max_value - 1) + 0.5F) / rtm::scalar_safe_to_float(max_value), 1.0F);
+		INFO("maxError: " << max_error);
+		float prev = -2.0F;
+		const float threshold = std::min(1.0E-6F, 1.0F / (1 << (num_bits + 1)));
+		for (uint32_t value = 0; value <= max_value; ++value)
+		{
+			INFO("value: " << int(value));
+
+#else
+
 		for (uint32_t value = 0; value < max_value; ++value)
 		{
+
+#endif
+
 			const float unpacked0 = unpack_scalar_unsigned(value, num_bits);
 			const uint32_t packed0 = pack_scalar_unsigned(unpacked0, num_bits);
 			if (packed0 != value || unpacked0 < 0.0F || unpacked0 > 1.0F)
 				num_errors++;
 
+#ifdef ACL_UNIT_TEST_STRICT
+
+			const float true_unsigned = float(value) / max_value;
+			if (std::fabs(true_unsigned - unpacked0) > threshold)
+			{
+				++num_errors;
+			}
+			CHECK(prev < unpacked0);
+			prev = unpacked0;
+
+#endif
+
+#ifndef ACL_PACKING_PRECISION_BOOST
+
 			const float unpacked1 = unpack_scalar_signed(value, num_bits);
 			const uint32_t packed1 = pack_scalar_signed(unpacked1, num_bits);
 			if (packed1 != value || unpacked1 < -1.0F || unpacked1 > 1.0F)
 				num_errors++;
+
+#endif
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+			if (value < max_value)
+			{
+				if (pack_scalar_unsigned(true_unsigned + max_error, num_bits) != value)
+				{
+					++num_errors;
+				}
+			}
+			if (value > 0)
+			{
+				if (pack_scalar_unsigned(true_unsigned - max_error, num_bits) != value)
+				{
+					++num_errors;
+				}
+			}
+
+#endif
+
 		}
 		CHECK(num_errors == 0);
 	}
 }
 
+#ifdef ACL_UNIT_TEST_STRICT
+
+TEST_CASE("unpack_scalarf_32_unsafe", "[math][scalar][packing]")
+
+#else
+
 TEST_CASE("unpack_scalarf_96_unsafe", "[math][scalar][packing]")
+
+#endif
+
 {
 	{
 		UnalignedBuffer tmp0;
@@ -99,12 +185,32 @@ TEST_CASE("unpack_scalarf_96_unsafe", "[math][scalar][packing]")
 
 			memcpy_bits(&tmp1.buffer[0], offset, &tmp0.buffer[0], 0, 32);
 			scalarf scalar1 = unpack_scalarf_32_unsafe(&tmp1.buffer[0], offset);
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+			if (!scalar_equal(vector_get_x(vec0), scalar_cast(scalar1)))
+
+#else
+
 			if (!scalar_near_equal(vector_get_x(vec0), scalar_cast(scalar1), 1.0E-6F))
+
+#endif
+
 				num_errors++;
 
 			memcpy_bits(&tmp1.buffer[0], offset, &tmp0.buffer[4], 0, 32);
 			scalar1 = unpack_scalarf_32_unsafe(&tmp1.buffer[0], offset);
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+			if (!scalar_equal(vector_get_y(vec0), scalar_cast(scalar1)))
+
+#else
+
 			if (!scalar_near_equal(vector_get_y(vec0), scalar_cast(scalar1), 1.0E-6F))
+
+#endif
+
 				num_errors++;
 		}
 		CHECK(num_errors == 0);
@@ -118,24 +224,88 @@ TEST_CASE("unpack_scalarf_uXX_unsafe", "[math][scalar][packing]")
 		alignas(16) uint8_t buffer[64];
 
 		uint32_t num_errors = 0;
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+		vector4f vec0;
+		scalarf scalar1;
+		scalarf scalar2;
+
+#else
+
 		vector4f vec0 = vector_set(unpack_scalar_unsigned(0, 16), unpack_scalar_unsigned(12355, 16), unpack_scalar_unsigned(43222, 16), unpack_scalar_unsigned(54432, 16));
 		pack_vector2_uXX_unsafe(vec0, 16, &buffer[0]);
 		scalarf scalar1 = unpack_scalarf_uXX_unsafe(16, &buffer[0], 0);
 		if (!scalar_near_equal(vector_get_x(vec0), scalar_cast(scalar1), 1.0E-6F))
 			num_errors++;
 
+#endif
+
 		for (uint8_t bit_rate = 1; bit_rate < k_highest_bit_rate; ++bit_rate)
 		{
 			uint32_t num_bits = get_num_bits_at_bit_rate(bit_rate);
 			uint32_t max_value = (1 << num_bits) - 1;
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+			INFO("num_bits: " << int(num_bits));
+			const float max_error = 1.0F - std::nextafter((rtm::scalar_safe_to_float(max_value - 1) + 0.5F) / rtm::scalar_safe_to_float(max_value), 1.0F);
+			INFO("maxError: " << max_error);
+			const float threshold = std::min(1.0E-6F, 1.0F / (1 << (num_bits + 1)));
+
+			vec0 = vector_set(0.0F, 1.0F, 0.0F, 0.0F);
+			pack_vector4_uXX_unsafe(vec0, num_bits, &buffer[0]);
+			scalar1 = unpack_scalarf_uXX_unsafe(num_bits, &buffer[0], 0);
+			if (!scalar_equal(vector_get_x(vec0), scalar1))
+			{
+				++num_errors;
+			}
+
+			scalar2 = unpack_scalarf_uXX_unsafe(num_bits, &buffer[0], num_bits);
+			if (!scalar_equal(vector_get_y(vec0), scalar2))
+			{
+				++num_errors;
+			}
+
+#endif
+
 			for (uint32_t value = 0; value <= max_value; ++value)
 			{
+
+#ifdef ACL_UNIT_TEST_STRICT
+
+				vec0 = vector_set(float(value) / max_value, 0.0F, 0.0F, 0.0F);
+
+				pack_vector4_uXX_unsafe(vec0, num_bits, &buffer[0]);
+				scalar1 = unpack_scalarf_uXX_unsafe(num_bits, &buffer[0], 0);
+				
+				pack_vector4_uXX_unsafe(vector_set(std::min(vector_get_x(vec0) + max_error, 1.0F)), num_bits, &buffer[0]);
+				scalar2 = unpack_scalarf_uXX_unsafe(num_bits, &buffer[0], 0);
+				if (!scalar_equal(scalar1, scalar2))
+				{
+					++num_errors;
+				}
+
+				pack_vector4_uXX_unsafe(vector_set(std::max(vector_get_x(vec0) - max_error, 0.0F)), num_bits, &buffer[0]);
+				scalar2 = unpack_scalarf_uXX_unsafe(num_bits, &buffer[0], 0);
+				if (!scalar_equal(scalar1, scalar2))
+				{
+					++num_errors;
+				}
+
+				if (!scalar_near_equal(vector_get_x(vec0), scalar_cast(scalar1), threshold))
+
+#else
+
 				const float value_unsigned = scalar_clamp(unpack_scalar_unsigned(value, num_bits), 0.0F, 1.0F);
 
 				vec0 = vector_set(value_unsigned, value_unsigned, value_unsigned);
 				pack_vector2_uXX_unsafe(vec0, num_bits, &buffer[0]);
 				scalar1 = unpack_scalarf_uXX_unsafe(num_bits, &buffer[0], 0);
 				if (!scalar_near_equal(vector_get_x(vec0), scalar_cast(scalar1), 1.0E-6F))
+
+#endif		
+				
 					num_errors++;
 
 				{
@@ -146,7 +316,17 @@ TEST_CASE("unpack_scalarf_uXX_unsafe", "[math][scalar][packing]")
 
 						memcpy_bits(&tmp0.buffer[0], offset, &buffer[0], 0, size_t(num_bits) * 4);
 						scalar1 = unpack_scalarf_uXX_unsafe(num_bits, &tmp0.buffer[0], offset);
+						
+#ifdef ACL_UNIT_TEST_STRICT
+
+						if (!scalar_equal(scalar1, scalar2))
+
+#else						
+
 						if (!scalar_near_equal(vector_get_x(vec0), scalar_cast(scalar1), 1.0E-6F))
+
+#endif
+
 							num_errors++;
 					}
 				}


### PR DESCRIPTION
This one is much simpler, and more successful.  Precision improves, and also saves a modest 0.6% of memory in my use case.  Win-win.  Feel free to link this to https://github.com/nfrechette/acl/issues/351.