### PR TITLE
fix: added bind transform support to clip_writer

### DIFF
--- a/includes/acl/io/clip_writer.h
+++ b/includes/acl/io/clip_writer.h
@@ -119,6 +119,31 @@ namespace acl
 			writer["constant_rotation_threshold_angle"] = format_hex_float(desc.constant_rotation_threshold_angle, buffer, sizeof(buffer));
 			writer["constant_translation_threshold"] = format_hex_float(desc.constant_translation_threshold, buffer, sizeof(buffer));
 			writer["constant_scale_threshold"] = format_hex_float(desc.constant_scale_threshold, buffer, sizeof(buffer));
+
+#ifdef ACL_BIND_POSE
+
+			writer["bind_rotation"] = [&](sjson::ArrayWriter& rotation_writer)
+			{
+				rotation_writer.push(acl_impl::format_hex_float(rtm::quat_get_x(desc.default_value.rotation), buffer, sizeof(buffer)));
+				rotation_writer.push(acl_impl::format_hex_float(rtm::quat_get_y(desc.default_value.rotation), buffer, sizeof(buffer)));
+				rotation_writer.push(acl_impl::format_hex_float(rtm::quat_get_z(desc.default_value.rotation), buffer, sizeof(buffer)));
+				rotation_writer.push(acl_impl::format_hex_float(rtm::quat_get_w(desc.default_value.rotation), buffer, sizeof(buffer)));
+			};
+			writer["bind_translation"] = [&](sjson::ArrayWriter& translation_writer)
+			{
+				translation_writer.push(acl_impl::format_hex_float(rtm::vector_get_x(desc.default_value.translation), buffer, sizeof(buffer)));
+				translation_writer.push(acl_impl::format_hex_float(rtm::vector_get_y(desc.default_value.translation), buffer, sizeof(buffer)));
+				translation_writer.push(acl_impl::format_hex_float(rtm::vector_get_z(desc.default_value.translation), buffer, sizeof(buffer)));
+			};
+			writer["bind_scale"] = [&](sjson::ArrayWriter& scale_writer)
+			{
+				scale_writer.push(acl_impl::format_hex_float(rtm::vector_get_x(desc.default_value.scale), buffer, sizeof(buffer)));
+				scale_writer.push(acl_impl::format_hex_float(rtm::vector_get_y(desc.default_value.scale), buffer, sizeof(buffer)));
+				scale_writer.push(acl_impl::format_hex_float(rtm::vector_get_z(desc.default_value.scale), buffer, sizeof(buffer)));
+			};
+
+#endif
+
 		}
 
 		inline void write_sjson_tracks(const track_array& track_list, sjson::Writer& writer)


### PR DESCRIPTION
This is one of the changes I needed to make to create the acl.sjson file referred to in https://github.com/nfrechette/acl/issues/353#issuecomment-856952432
It only manifests as a single commit in the pull request preview, so I presume that this is clean enough.  LMK otherwise.