### PR TITLE
Add support for interpolation masking

### DIFF
--- a/includes/acl/core/interpolation_mask.h
+++ b/includes/acl/core/interpolation_mask.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "acl/core/error_result.h"
+#include "acl/core/iallocator.h"
+#include "acl/core/interpolation_utils.h"
+
+#include <cstdint>
+
+ACL_IMPL_FILE_PRAGMA_PUSH
+
+namespace acl
+{
+	/////////////////////////////////////////////////////////////////////////////////
+	// An interpolation_mask is a bit field with 2-bits per element, specifying a
+	// SampleRoundingPolicy for each element
+	class alignas(16) interpolation_mask final
+	{
+	public:
+		////////////////////////////////////////////////////////////////////////////////
+		// Make an interpolation mask for the given number of elements.
+		static ErrorResult make_from_num_elements(IAllocator& allocator, uint32_t num_elements, interpolation_mask*& out_mask)
+		{
+			uint32_t buffer_size = 0;
+			buffer_size += sizeof(interpolation_mask);
+			ACL_ASSERT(is_aligned_to(buffer_size, alignof(interpolation_mask)), "Invalid alignment");
+			buffer_size += sizeof(uint32_t) * ((uint32_t(num_elements) + 16 - 1) / 16); // 2 bits per element
+
+			// Ensure we have sufficient padding for unaligned 16 byte loads
+			buffer_size += 15;
+
+			uint8_t* buffer = allocate_type_array_aligned<uint8_t>(allocator, buffer_size, 16);
+			if (!buffer)
+			{
+				return ErrorResult("Failed to allocate interpolation_mask");
+			}
+			std::memset(buffer, 0, buffer_size);
+
+			out_mask = new(buffer) interpolation_mask(buffer_size, num_elements);
+			out_mask->m_size = buffer_size;
+			out_mask->m_num_elements = num_elements;
+
+			return ErrorResult();
+		}
+
+		////////////////////////////////////////////////////////////////////////////////
+		// Returns the number of elements in the mask
+		uint32_t get_num_elements() const noexcept { return m_num_elements; }
+
+		////////////////////////////////////////////////////////////////////////////////
+		// Returns the size in bytes of the interpolation mask.
+		// Includes the 'interpolation_mask' instance size.
+		uint32_t get_num_bytes() const noexcept { return m_size; }
+
+		////////////////////////////////////////////////////////////////////////////////
+		// Get the SampleRoundingPolicy for a particular element in the mask
+		SampleRoundingPolicy get(uint32_t index) const
+		{
+			uint32_t * const bitfield = get_bitfield();
+			ACL_ASSERT(index < m_num_elements, "Invalid bit index %u (num elements = %u)", index, m_num_elements);
+			uint32_t const bits = bitfield[index / 16];
+			uint32_t const shift = (30 - (index % 16) * 2);
+			uint32_t const mask = 0x03 << shift;
+			return static_cast<SampleRoundingPolicy>((bits & mask) >> shift);
+		}
+
+		////////////////////////////////////////////////////////////////////////////////
+		// Set the SampleRoundingPolicy for a particular element in the mask
+		void set(uint32_t index, SampleRoundingPolicy value)
+		{
+			uint32_t * const bitfield = get_bitfield();
+			ACL_ASSERT(index < m_num_elements, "Invalid bit index %u (num elements = %u)", index, m_num_elements);
+			uint32_t const bits = bitfield[index / 16];
+			uint32_t const shift = (30 - (index % 16) * 2);
+			uint32_t const mask = 0x3 << shift;
+			bitfield[index / 16] = (bits & ~mask) | (static_cast<uint32_t>(value) << shift);
+		}
+
+	private:
+		
+		////////////////////////////////////////////////////////////////////////////////
+		// Hide everything
+		interpolation_mask(uint32_t size_of_buffer, uint32_t num_elements) noexcept
+			: m_size(size_of_buffer)
+			, m_num_elements(num_elements)
+		{
+		}
+		interpolation_mask(const interpolation_mask&) = delete;
+		interpolation_mask(interpolation_mask&&) = delete;
+		interpolation_mask* operator=(const interpolation_mask&) = delete;
+		interpolation_mask* operator=(interpolation_mask&&) = delete;
+
+		////////////////////////////////////////////////////////////////////////////////
+		// Returns a pointer to the underlying bit-field data for this interpolation mask 
+		uint32_t * get_bitfield() const { return add_offset_to_ptr<uint32_t>(this, sizeof(this)); }
+
+		////////////////////////////////////////////////////////////////////////////////
+		// Raw buffer details.
+		////////////////////////////////////////////////////////////////////////////////
+
+		// Total size in bytes of the interpolation mask, including sizeof(interpolation_mask)
+		// and the underlying bit-field that immediately follows this struct
+		uint32_t m_size;
+
+		////////////////////////////////////////////////////////////////////////////////
+		// Interpolation mask header.
+		////////////////////////////////////////////////////////////////////////////////
+
+		uint32_t m_num_elements;
+		
+		uint8_t padding[8];
+
+		//////////////////////////////////////////////////////////////////////////
+		// Interpolation mask bits follows here in memory.
+		//////////////////////////////////////////////////////////////////////////
+	};
+}
+
+ACL_IMPL_FILE_PRAGMA_POP

--- a/includes/acl/core/interpolation_utils.h
+++ b/includes/acl/core/interpolation_utils.h
@@ -62,6 +62,24 @@ namespace acl
 	};
 
 	//////////////////////////////////////////////////////////////////////////
+	// Modify an interpolation alpha value given a sample rounding policy
+	inline float apply_rounding_policy(float const interpolation_alpha, SampleRoundingPolicy const policy)
+	{
+		switch (policy)
+		{
+		default:
+		case SampleRoundingPolicy::None:
+			return interpolation_alpha;
+		case SampleRoundingPolicy::Floor:
+			return 0.0F;
+		case SampleRoundingPolicy::Ceil:
+			return 1.0F;
+		case SampleRoundingPolicy::Nearest:
+			return floor(interpolation_alpha + 0.5F);
+		}
+	}
+
+	//////////////////////////////////////////////////////////////////////////
 	// Calculates the sample indices and the interpolation required to linearly
 	// interpolate when the samples are uniform.
 	// The returned sample indices are clamped and do not loop.
@@ -88,23 +106,7 @@ namespace acl
 
 		out_sample_index0 = sample_index0;
 		out_sample_index1 = sample_index1;
-
-		switch (rounding_policy)
-		{
-		default:
-		case SampleRoundingPolicy::None:
-			out_interpolation_alpha = interpolation_alpha;
-			break;
-		case SampleRoundingPolicy::Floor:
-			out_interpolation_alpha = 0.0F;
-			break;
-		case SampleRoundingPolicy::Ceil:
-			out_interpolation_alpha = 1.0F;
-			break;
-		case SampleRoundingPolicy::Nearest:
-			out_interpolation_alpha = floor(interpolation_alpha + 0.5F);
-			break;
-		}
+		out_interpolation_alpha = apply_rounding_policy(interpolation_alpha, rounding_policy);
 	}
 
 	ACL_DEPRECATED("Use find_linear_interpolation_samples_with_duration instead, to be removed in v2.0")

--- a/includes/acl/decompression/decompress_data.h
+++ b/includes/acl/decompression/decompress_data.h
@@ -711,7 +711,7 @@ namespace acl
 	}
 
 	template <class SettingsType, class DecompressionContextType, class SamplingContextType>
-	inline Quat_32 ACL_SIMD_CALL decompress_and_interpolate_rotation(const SettingsType& settings, const ClipHeader& header, const DecompressionContextType& decomp_context, SamplingContextType& sampling_context)
+	inline Quat_32 ACL_SIMD_CALL decompress_and_interpolate_rotation(const SettingsType& settings, const ClipHeader& header, const DecompressionContextType& decomp_context, float const interpolation_alpha, SamplingContextType& sampling_context)
 	{
 		static_assert(SamplingContextType::k_num_samples_to_interpolate == 2 || SamplingContextType::k_num_samples_to_interpolate == 4, "Unsupported number of samples");
 
@@ -1031,9 +1031,9 @@ namespace acl
 				}
 
 				if (static_condition<num_key_frames == 4>::test())
-					interpolated_rotation = SamplingContextType::interpolate_rotation(rotation0, rotation1, rotation2, rotation3, decomp_context.interpolation_alpha);
+					interpolated_rotation = SamplingContextType::interpolate_rotation(rotation0, rotation1, rotation2, rotation3, interpolation_alpha);
 				else
-					interpolated_rotation = SamplingContextType::interpolate_rotation(rotation0, rotation1, decomp_context.interpolation_alpha);
+					interpolated_rotation = SamplingContextType::interpolate_rotation(rotation0, rotation1, interpolation_alpha);
 
 				ACL_ASSERT(quat_is_finite(interpolated_rotation), "Rotation is not valid!");
 				ACL_ASSERT(quat_is_normalized(interpolated_rotation), "Rotation is not normalized!");
@@ -1045,7 +1045,7 @@ namespace acl
 	}
 
 	template<class SettingsAdapterType, class DecompressionContextType, class SamplingContextType>
-	inline Vector4_32 ACL_SIMD_CALL decompress_and_interpolate_vector(const SettingsAdapterType& settings, const ClipHeader& header, const DecompressionContextType& decomp_context, SamplingContextType& sampling_context)
+	inline Vector4_32 ACL_SIMD_CALL decompress_and_interpolate_vector(const SettingsAdapterType& settings, const ClipHeader& header, const DecompressionContextType& decomp_context, float const interpolation_alpha, SamplingContextType& sampling_context)
 	{
 		static_assert(SamplingContextType::k_num_samples_to_interpolate == 2 || SamplingContextType::k_num_samples_to_interpolate == 4, "Unsupported number of samples");
 
@@ -1240,9 +1240,9 @@ namespace acl
 				}
 
 				if (static_condition<num_key_frames == 4>::test())
-					interpolated_vector = SamplingContextType::interpolate_vector4(vector0, vector1, vector2, vector3, decomp_context.interpolation_alpha);
+					interpolated_vector = SamplingContextType::interpolate_vector4(vector0, vector1, vector2, vector3, interpolation_alpha);
 				else
-					interpolated_vector = SamplingContextType::interpolate_vector4(vector0, vector1, decomp_context.interpolation_alpha);
+					interpolated_vector = SamplingContextType::interpolate_vector4(vector0, vector1, interpolation_alpha);
 
 				ACL_ASSERT(vector_is_finite3(interpolated_vector), "Vector is not valid!");
 			}

--- a/includes/acl/decompression/impl/track_sampling_impl.h
+++ b/includes/acl/decompression/impl/track_sampling_impl.h
@@ -26,6 +26,7 @@
 
 #include "acl/core/compiler_utils.h"
 #include "acl/core/compressed_tracks.h"
+#include "acl/core/interpolation_mask.h"
 
 #include <rtm/scalarf.h>
 #include <rtm/vector4f.h>
@@ -53,7 +54,10 @@ namespace acl
 
 			uint32_t key_frame_bit_offsets[2];				//  20 |  24	// Variable quantization
 
-			uint8_t padding_tail[sizeof(void*) == 4 ? 36 : 32];
+			// Interpolation mask
+			const interpolation_mask* interp_mask;			//  28 |  32
+
+			uint8_t padding_tail[sizeof(void*) == 4 ? 32 : 24];
 
 			//////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
An interpolation mask allows us to specify a SampleRoundingPolicy on a per-bone or per-float-channel basis.