### PR TITLE
refactor: avoid using strlen to test for empty strings

### DIFF
--- a/includes/acl/core/string.h
+++ b/includes/acl/core/string.h
@@ -142,7 +142,7 @@ namespace acl
 
 		const char* c_str() const noexcept { return m_c_str != nullptr ? m_c_str : ""; }
 		size_t size() const noexcept { return m_c_str != nullptr ? std::strlen(m_c_str) : 0; }
-		bool empty() const noexcept { return m_c_str != nullptr ? (std::strlen(m_c_str) == 0) : true; }
+		bool empty() const noexcept { return m_c_str != nullptr ? (m_c_str[0] == '\0') : true; }
 
 	private:
 		iallocator* m_allocator;

--- a/tools/acl_compressor/sources/acl_compressor.cpp
+++ b/tools/acl_compressor/sources/acl_compressor.cpp
@@ -386,7 +386,7 @@ static bool parse_options(int argc, char** argv, Options& options)
 #if defined(__ANDROID__)
 	if (options.input_buffer == nullptr || options.input_buffer_size == 0)
 #else
-	if (options.input_filename == nullptr || std::strlen(options.input_filename) == 0)
+	if (options.input_filename == nullptr || options.input_filename[0] == '\0')
 #endif
 	{
 		printf("An input file is required.\n");
@@ -1046,7 +1046,7 @@ static int safe_main_impl(int argc, char* argv[])
 #if defined(__ANDROID__)
 	if (options.config_buffer != nullptr && options.config_buffer_size != 0)
 #else
-	if (options.config_filename != nullptr && std::strlen(options.config_filename) != 0)
+	if (options.config_filename != nullptr && options.config_filename[0] != '\0')
 #endif
 	{
 		// Override whatever the ACL SJSON file might have contained


### PR DESCRIPTION
@nfrechette, minor fix, but with frequent use empty() function, it makes sense.