### PR TITLE
feat(compression): add context to error metric conversion args

### DIFF
--- a/includes/acl/compression/impl/quantize_streams.h
+++ b/includes/acl/compression/impl/quantize_streams.h
@@ -242,9 +242,13 @@ namespace acl
 				convert_transforms_args_raw.num_dirty_transforms = num_bones;
 				convert_transforms_args_raw.transforms = raw_local_pose;
 				convert_transforms_args_raw.num_transforms = num_bones;
+				convert_transforms_args_raw.sample_index = 0;
+				convert_transforms_args_raw.is_lossy = false;
+				convert_transforms_args_raw.is_base = false;
 
 				itransform_error_metric::convert_transforms_args convert_transforms_args_base = convert_transforms_args_raw;
 				convert_transforms_args_base.transforms = additive_local_pose;
+				convert_transforms_args_base.is_base = true;
 
 				itransform_error_metric::apply_additive_to_base_args apply_additive_to_base_args_raw;
 				apply_additive_to_base_args_raw.dirty_transform_indices = self_transform_indices;
@@ -271,7 +275,10 @@ namespace acl
 					uint8_t* sample_raw_local_transforms = raw_local_transforms + (sample_index * sample_transform_size);
 
 					if (needs_conversion)
+					{
+						convert_transforms_args_raw.sample_index = sample_index;
 						convert_transforms_impl(error_metric_, convert_transforms_args_raw, sample_raw_local_transforms);
+					}
 					else
 						std::memcpy(sample_raw_local_transforms, raw_local_pose, sample_transform_size);
 
@@ -284,7 +291,10 @@ namespace acl
 						uint8_t* sample_base_local_transforms = base_local_transforms + (sample_index * sample_transform_size);
 
 						if (needs_conversion)
+						{
+							convert_transforms_args_base.sample_index = sample_index;
 							convert_transforms_impl(error_metric_, convert_transforms_args_base, sample_base_local_transforms);
+						}
 						else
 							std::memcpy(sample_base_local_transforms, additive_local_pose, sample_transform_size);
 
@@ -678,6 +688,9 @@ namespace acl
 			convert_transforms_args_lossy.num_dirty_transforms = 1;
 			convert_transforms_args_lossy.transforms = context.lossy_local_pose;
 			convert_transforms_args_lossy.num_transforms = num_transforms;
+			convert_transforms_args_lossy.sample_index = 0;
+			convert_transforms_args_lossy.is_lossy = true;
+			convert_transforms_args_lossy.is_base = false;
 
 			itransform_error_metric::apply_additive_to_base_args apply_additive_to_base_args_lossy;
 			apply_additive_to_base_args_lossy.dirty_transform_indices = &target_bone_index;
@@ -710,7 +723,10 @@ namespace acl
 				context.bit_rate_database.sample(context.local_query, sample_time, context.lossy_local_pose, num_transforms);
 
 				if (needs_conversion)
+				{
+					convert_transforms_args_lossy.sample_index = sample_index;
 					convert_transforms_impl(error_metric, convert_transforms_args_lossy, context.local_transforms_converted);
+				}
 
 				if (has_additive_base)
 				{
@@ -762,6 +778,9 @@ namespace acl
 			convert_transforms_args_lossy.num_dirty_transforms = context.num_bones_in_chain;
 			convert_transforms_args_lossy.transforms = context.lossy_local_pose;
 			convert_transforms_args_lossy.num_transforms = context.num_bones;
+			convert_transforms_args_lossy.sample_index = 0;
+			convert_transforms_args_lossy.is_lossy = true;
+			convert_transforms_args_lossy.is_base = false;
 
 			itransform_error_metric::apply_additive_to_base_args apply_additive_to_base_args_lossy;
 			apply_additive_to_base_args_lossy.dirty_transform_indices = context.chain_bone_indices;
@@ -801,7 +820,10 @@ namespace acl
 				context.bit_rate_database.sample(context.object_query, sample_time, context.lossy_local_pose, context.num_bones);
 
 				if (needs_conversion)
+				{
+					convert_transforms_args_lossy.sample_index = sample_index;
 					convert_transforms_impl(error_metric, convert_transforms_args_lossy, context.local_transforms_converted);
+				}
 
 				if (has_additive_base)
 				{
@@ -1611,6 +1633,9 @@ namespace acl
 			convert_transforms_args_lossy.num_dirty_transforms = num_bones;
 			convert_transforms_args_lossy.transforms = context.lossy_local_pose;
 			convert_transforms_args_lossy.num_transforms = num_bones;
+			convert_transforms_args_lossy.sample_index = 0;
+			convert_transforms_args_lossy.is_lossy = true;
+			convert_transforms_args_lossy.is_base = false;
 
 			itransform_error_metric::apply_additive_to_base_args apply_additive_to_base_args_lossy;
 			apply_additive_to_base_args_lossy.dirty_transform_indices = context.self_transform_indices;
@@ -1702,7 +1727,10 @@ namespace acl
 
 						// Convert to our object space representation
 						if (needs_conversion)
+						{
+							convert_transforms_args_lossy.sample_index = interp_frame_index;
 							convert_transforms_impl(error_metric, convert_transforms_args_lossy, context.local_transforms_converted);
+						}
 
 						if (has_additive_base)
 						{

--- a/includes/acl/compression/impl/track_error.impl.h
+++ b/includes/acl/compression/impl/track_error.impl.h
@@ -274,12 +274,17 @@ namespace acl
 			convert_transforms_args_raw.num_dirty_transforms = num_tracks;
 			convert_transforms_args_raw.transforms = tracks_writer0.tracks_typed.qvvf;
 			convert_transforms_args_raw.num_transforms = num_tracks;
+			convert_transforms_args_raw.sample_index = 0;
+			convert_transforms_args_raw.is_lossy = false;
+			convert_transforms_args_raw.is_base = false;
 
 			itransform_error_metric::convert_transforms_args convert_transforms_args_base = convert_transforms_args_raw;
 			convert_transforms_args_base.transforms = tracks_writer_base.tracks_typed.qvvf;
+			convert_transforms_args_base.is_base = true;
 
 			itransform_error_metric::convert_transforms_args convert_transforms_args_lossy = convert_transforms_args_raw;
 			convert_transforms_args_lossy.transforms = tracks_writer1_remapped.tracks_typed.qvvf;
+			convert_transforms_args_lossy.is_lossy = true;
 
 			itransform_error_metric::apply_additive_to_base_args apply_additive_to_base_args_raw;
 			apply_additive_to_base_args_raw.dirty_transform_indices = self_transform_indices;
@@ -317,6 +322,8 @@ namespace acl
 
 				if (needs_conversion)
 				{
+					convert_transforms_args_raw.sample_index = sample_index;
+					convert_transforms_args_lossy.sample_index = sample_index;
 					error_metric.convert_transforms(convert_transforms_args_raw, raw_local_pose_converted);
 					error_metric.convert_transforms(convert_transforms_args_lossy, lossy_local_pose_converted);
 				}
@@ -328,7 +335,10 @@ namespace acl
 					args.adapter.sample_tracks_base(additive_sample_time, rounding_policy, tracks_writer_base);
 
 					if (needs_conversion)
+					{
+						convert_transforms_args_base.sample_index = sample_index;
 						error_metric.convert_transforms(convert_transforms_args_base, base_local_pose_converted);
+					}
 
 					error_metric.apply_additive_to_base(apply_additive_to_base_args_raw, raw_local_pose_);
 					error_metric.apply_additive_to_base(apply_additive_to_base_args_lossy, lossy_local_pose_);

--- a/includes/acl/compression/transform_error_metrics.h
+++ b/includes/acl/compression/transform_error_metrics.h
@@ -93,6 +93,21 @@ namespace acl
 			//////////////////////////////////////////////////////////////////////////
 			// The number of transforms in the input and output buffers.
 			uint32_t num_transforms;
+
+			//////////////////////////////////////////////////////////////////////////
+			// The sample index these transforms come from.
+			uint32_t sample_index;
+
+			//////////////////////////////////////////////////////////////////////////
+			// True if these transforms are being converted from lossy data.
+			// False if these transforms are being converted from the original uncompressed data.
+			bool is_lossy;
+
+			//////////////////////////////////////////////////////////////////////////
+			// True if these transforms are being converted from the base pose.
+			// False if these transforms are being converted from the additive pose.
+			// If not using a base, this value is always false.
+			bool is_base;
 		};
 
 		//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is about four months later than I had hoped, but better late than never!

This adds extra context to custom error metrics that wish to compensate for external factors such as animated world space lattice deforms or in my case, already compressed scale factors.

I wasn't sure if two bools or an enum were better for describing is_lossy and is_base. I ended up with the approach I did in case there would ever be a lossy base in the future where both the base and all overrides were compressed in one go. But if there's a desire to change that to an enum, I would have no problem changing it.

Thanks for all the work you do! Hyped for 2.1 after the latest blog post!