### PR TITLE
fix(compression): use correct sample index in error metric conversion…

### DIFF
--- a/includes/acl/compression/impl/compact_constant_streams.h
+++ b/includes/acl/compression/impl/compact_constant_streams.h
@@ -148,6 +148,8 @@ namespace acl
 
 				if (needs_conversion)
 				{
+					convert_transforms_args_local.sample_index = sample_index;
+
 					convert_transforms_args_local.transforms = &local_transforms[0];
 					convert_transforms_args_local.is_lossy = false;
 
@@ -185,7 +187,10 @@ namespace acl
 					base_transforms[1] = base_transform;
 
 					if (needs_conversion)
+					{
+						convert_transforms_args_base.sample_index = base_sample_index;
 						error_metric.convert_transforms(convert_transforms_args_base, &base_transforms_converted[0]);
+					}
 					else
 						std::memcpy(&base_transforms_converted[0], &base_transforms[0], metric_transform_size * 2);
 

--- a/includes/acl/compression/impl/optimize_looping.h
+++ b/includes/acl/compression/impl/optimize_looping.h
@@ -95,6 +95,7 @@ namespace acl
 			convert_transforms_args_local.num_dirty_transforms = 2;
 			convert_transforms_args_local.transforms = &local_transforms[0];
 			convert_transforms_args_local.num_transforms = 2;
+			convert_transforms_args_local.sample_index = last_sample_index;
 			convert_transforms_args_local.is_additive_base = false;
 			convert_transforms_args_local.is_lossy = true;
 
@@ -150,6 +151,7 @@ namespace acl
 					const transform_streams& additive_base_bone_stream = additive_base_segment.bone_streams[transform_index];
 
 					const uint32_t base_last_sample_index = additive_base_segment.num_samples - 1;
+					convert_transforms_args_base.sample_index = base_last_sample_index;
 
 					const rtm::quatf base_first_rotation = additive_base_bone_stream.rotations.get_sample_clamped(0);
 					const rtm::vector4f base_first_translation = additive_base_bone_stream.translations.get_sample_clamped(0);

--- a/includes/acl/compression/impl/quantize_streams.h
+++ b/includes/acl/compression/impl/quantize_streams.h
@@ -292,7 +292,8 @@ namespace acl
 
 						if (needs_conversion)
 						{
-							convert_transforms_args_base.sample_index = sample_index;
+							const uint32_t nearest_base_sample_index = static_cast<uint32_t>(rtm::scalar_round_bankers(normalized_sample_time * additive_base_clip.num_samples));
+							convert_transforms_args_base.sample_index = nearest_base_sample_index;
 							convert_transforms_impl(error_metric_, convert_transforms_args_base, sample_base_local_transforms);
 						}
 						else

--- a/includes/acl/compression/impl/track_error.impl.h
+++ b/includes/acl/compression/impl/track_error.impl.h
@@ -336,7 +336,8 @@ namespace acl
 
 					if (needs_conversion)
 					{
-						convert_transforms_args_base.sample_index = sample_index;
+						const uint32_t nearest_base_sample_index = static_cast<uint32_t>(rtm::scalar_round_bankers(normalized_sample_time * additive_num_samples));
+						convert_transforms_args_base.sample_index = nearest_base_sample_index;
 						error_metric.convert_transforms(convert_transforms_args_base, base_local_pose_converted);
 					}
 


### PR DESCRIPTION
… args

Constant streams were missing the sample_index. Looping optimization should use the last sample rather than the first, since that is the sample that is being "compressed" by the looping optimization. And additive base sample indices should be relative to the base. For that, nearest sampling is used.