### PR TITLE
fix: uninitialized value in write_format_per_track_data

### DIFF
--- a/includes/acl/compression/impl/write_stream_data.h
+++ b/includes/acl/compression/impl/write_stream_data.h
@@ -470,7 +470,7 @@ namespace acl
 			// The last group of each sub-track may or may not have padding. The last group might be less than 4 sub-tracks.
 
 			// To keep decompression simpler, rotations are padded to 4 elements even if the last group is partial
-			uint8_t format_per_track_group[4];
+			uint8_t format_per_track_group[4] = { 0 };
 
 			auto group_filter_action = [&segment](animation_track_type8 group_type, uint32_t bone_index)
 			{


### PR DESCRIPTION
Hi ! First thanks a lot for your library 😃 

I stumbled upon a consistency issue when re-compressing an animation:

In the `group_flush_action()` lambda, the `group_size` var is overridden by 4 in the case of a rotation. In most cases that's fine because we'll memset the next group to 0. But if we have a single rotation group with less than 4 entries, then we rely on the uninitialized values from the stack.
