### PR TITLE
refactor(core): move popcnt/lzcnt/BMI enabling macros into config.impl.h

### DIFF
--- a/includes/acl/config.h
+++ b/includes/acl/config.h
@@ -81,14 +81,18 @@
 // You can disable deprecation warnings by defining ACL_NO_DEPRECATION
 //#define ACL_NO_DEPRECATION
 
-// Popcount intrinsic support can be enabled by defining ACL_USE_POPCOUNT
+// x86 popcount/leading zero count intrinsic support can be enabled by defining ACL_USE_POPCOUNT
 // Note that this is a hardware feature and if the CPU does not support it, the
 // behavior is undefined. Make sure your platform supports it before enabling this.
+// XboxOne and PlayStation 4 are both based on AMD Jaguar which supports this. New generations support it as well.
+// popcnt/lzcnt are a minimum requirement for Windows 11.
 //#define ACL_USE_POPCOUNT
 
-// BMI intrinsic support can be enabled by defining ACL_BMI_INTRINSICS
+// x86 BMI intrinsic support can be enabled by defining ACL_BMI_INTRINSICS
 // Note that this is a hardware feature and if the CPU does not support it, the
 // behavior is undefined. Make sure your platform supports it before enabling this.
+// XboxOne and PlayStation 4 are both based on AMD Jaguar which supports this. New generations support it as well.
+// BMI is a minimum requirement for Windows 11.
 //#define ACL_BMI_INTRINSICS
 
 // Disables usage of 8-wide AVX when AVX is enabled
@@ -119,3 +123,7 @@
 // This is handy to debug the code and to more easily view
 // the generated assembly for each piece
 //#define ACL_IMPL_ENABLE_DEBUG_FORCE_INLINE
+
+////////////////////////////////////////////////////////////////////////////////
+// Macro feature validation and auto-detection is implemented in its own header
+#include "acl/core/impl/config.impl.h"

--- a/includes/acl/core/bit_manip_utils.h
+++ b/includes/acl/core/bit_manip_utils.h
@@ -35,34 +35,9 @@
 
 // See config.h for details on how to configure the hardware bitscan features for your project
 
-#if !defined(ACL_USE_POPCOUNT) && !defined(RTM_NO_INTRINSICS)
-	// TODO: Enable this for other publicly available console defines as well
-	#if defined(_DURANGO) || defined(_XBOX_ONE)
-		// Enable pop-count type instructions on Xbox One
-		#define ACL_USE_POPCOUNT
-	#endif
-#endif
-
 #if defined(ACL_USE_POPCOUNT)
 	// The popcount intrinsic is enabled
 	#include <nmmintrin.h>
-#endif
-
-// BMI intrinsic support
-#if !defined(ACL_BMI_INTRINSICS) && !defined(RTM_NO_INTRINSICS)
-	// TODO: Enable this for other publicly available console defines as well
-	#if defined(_DURANGO) || defined(_XBOX_ONE)
-		// Enable BMI type instructions on Xbox One
-		#define ACL_BMI_INTRINSICS
-	#elif defined(__BMI__)
-		// Clang and GCC define __BMI__ when -mbmi is used
-		#define ACL_BMI_INTRINSICS
-	#elif defined(RTM_AVX_INTRINSICS) && defined(RTM_COMPILER_MSVC)
-		// Enable BMI when AVX is enabled except with clang under Windows
-		// Note: It seems that the Clang toolchain with MSVC enables BMI only with AVX2 unlike
-		// MSVC which enables it with AVX
-		#define ACL_BMI_INTRINSICS
-	#endif
 #endif
 
 #if defined(ACL_BMI_INTRINSICS)

--- a/includes/acl/core/impl/config.impl.h
+++ b/includes/acl/core/impl/config.impl.h
@@ -1,0 +1,67 @@
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////
+// The MIT License (MIT)
+//
+// Copyright (c) 2025 Nicholas Frechette & Animation Compression Library contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+////////////////////////////////////////////////////////////////////////////////
+
+// Included only once from config.h
+
+#include <rtm/impl/detect_arch.h>
+
+// popcnt/lzcnt intrinsic support
+#if !defined(ACL_USE_POPCOUNT) && !defined(RTM_NO_INTRINSICS)
+	// TODO: Enable this for other publicly available console defines as well
+	#if defined(_DURANGO) || defined(_XBOX_ONE)
+		// Enable pop-count type instructions on Xbox One
+		#define ACL_USE_POPCOUNT
+	#endif
+#endif
+
+#if defined(ACL_USE_POPCOUNT)
+	#if !(defined(RTM_ARCH_X86) || defined(RTM_ARCH_X64))
+		static_assert(false, "ACL_USE_POPCOUNT can only be used on x86/x64 architectures");
+	#endif
+#endif
+
+// BMI intrinsic support
+#if !defined(ACL_BMI_INTRINSICS) && !defined(RTM_NO_INTRINSICS)
+	// TODO: Enable this for other publicly available console defines as well
+	#if defined(_DURANGO) || defined(_XBOX_ONE)
+		// Enable BMI type instructions on Xbox One
+		#define ACL_BMI_INTRINSICS
+	#elif defined(__BMI__)
+		// Clang and GCC define __BMI__ when -mbmi is used
+		#define ACL_BMI_INTRINSICS
+	#elif defined(RTM_AVX_INTRINSICS) && defined(RTM_COMPILER_MSVC)
+		// Enable BMI when AVX is enabled except with clang under Windows
+		// Note: It seems that the Clang toolchain with MSVC enables BMI only with AVX2 unlike
+		// MSVC which enables it with AVX
+		#define ACL_BMI_INTRINSICS
+	#endif
+#endif
+
+#if defined(ACL_BMI_INTRINSICS)
+	#if !(defined(RTM_ARCH_X86) || defined(RTM_ARCH_X64))
+		static_assert(false, "ACL_BMI_INTRINSICS can only be used on x86/x64 architectures");
+	#endif
+#endif


### PR DESCRIPTION
Also improved documentation around them

Fixes #527